### PR TITLE
Set initial SessionList to be empty and initial currentSession as null

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -11,6 +11,8 @@ TAskmaster is a **desktop app for managing students, optimised for use via a Com
     - [Adding a student: `add`](#Adding-a-student-add "Goto Adding-a-student-add")
     - [Listing all students: `list`](#Listing-all-students-list "Goto Listing-all-students-list")
     - [Deleting a student: `delete`](#Deleting-a-student-delete "Goto Deleting-a-student-delete")
+    - [Adding a session: `session`](#Adding-a-session-session "Goto Adding-a-session-session")
+    - [Changing the current session: `goto`](#Changing-the-current-session-goto "Goto Changing-the-current-session-goto")
     - [Marking a student's attendance: `mark`](#Marking-a-student’s-attendance-mark "Goto Marking-a-students-attendance-mark")
     - [Storing students' attendance records: `store_record`](#Storing-students’-attendance-records-store_record "Goto Storing-students'-attendance-records")
     - [Loading students' attendance records: `load_record`](#Loading-students’-attendance-records-load_record "Goto Loading-students'-attendance-records")
@@ -52,6 +54,20 @@ delete INDEX
 ```
 - Deletes the student at the specified `INDEX` number shown in the displayed student list.
 - The `INDEX` **must be a positive integer**.
+
+### Adding a session: `session`
+Adds a session into the session list.
+```
+session s/SESSION_NAME dt/SESSION_DATE_TIME
+```
+- The `SESSION_DATE_TIME` must be of the format `dd-MM-yyyy HHmm`.
+
+### Changing the current session: `goto`
+Changes the current session to the session with the specified name.
+```
+goto s/SESSION_NAME
+```
+- The `SESSION_NAME` must belong to one of the existing sessions in the session list.
 
 ### Marking a student's attendance: `mark`
 Marks the attendance of the specified student from the student list.
@@ -100,15 +116,18 @@ exit
 ```
 
 ## Command Summary
-| Action | Format, Examples                                                                                        |
-|--------|---------------------------------------------------------------------------------------------------------|
-| Add    | ```add n/NAME i/NUSNET_ID e/EMAIL``` <br> e.g., ```add n/John Doe Kai Jie i/E9412345 e/e9412345@u.nus.edu```|
-| List   | ```list```                                                                                               |
-| Delete | ```delete INDEX``` <br> e.g., ```delete 3```                                                             |
-| Mark   | `mark INDEX a/ATTENDANCE_TYPE` <br> e.g., `mark 1 a/present`                                             |
-| Store Attendance | `store_record fn/FILENAME` <br> e.g., `store_record tutorial01`                                |
-| Load Attendance | `load_record fn/FILENAME`
-| Clear  | ```clear```                                                                                              |
+| Action            | Format, Examples                                                                                              |
+|-------------------|---------------------------------------------------------------------------------------------------------------|
+| Add student       | ```add n/NAME i/NUSNET_ID e/EMAIL``` <br> e.g., ```add n/John Doe Kai Jie i/E9412345 e/e9412345@u.nus.edu```  |
+| List students     | ```list```                                                                                               |
+| Delete student    | ```delete INDEX``` <br> e.g., ```delete 3```                                                             |
+| Add session       | ```session s/SESSION_NAME dt/SESSION_DATE_TIME``` <br> e.g., ```session s/CS2103 Tutorial 1 dt/23-10-2020 0900```|
+| Change session    | ```goto s/SESSION_NAME``` <br> e.g., ```goto s/CS2103 Tutorial 1```
+| Mark              | ```mark INDEX a/ATTENDANCE_TYPE``` <br> e.g., `mark 1 a/present`                                             |
+| Mark all          | ```mark all a/ATTENDANCE_TYPE``` <br> e.g., `mark all a/present`
+| Store Attendance  | ```store_record fn/FILENAME``` <br> e.g., `store_record tutorial01`                                |
+| Load Attendance   | ```load_record fn/FILENAME```
+| Clear             | ```clear```                                                                                              |
 
 
 ## Frequently Asked Questions (FAQ)

--- a/src/main/java/seedu/taskmaster/logic/commands/MarkAllCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/MarkAllCommand.java
@@ -8,6 +8,8 @@ import java.util.List;
 import seedu.taskmaster.logic.commands.exceptions.CommandException;
 import seedu.taskmaster.model.Model;
 import seedu.taskmaster.model.record.AttendanceType;
+import seedu.taskmaster.model.session.exceptions.NoSessionException;
+import seedu.taskmaster.model.session.exceptions.SessionException;
 import seedu.taskmaster.model.student.Student;
 
 public class MarkAllCommand extends MarkCommand {
@@ -31,7 +33,11 @@ public class MarkAllCommand extends MarkCommand {
 
         List<Student> lastShownList = model.getFilteredStudentList();
 
-        model.markAllStudents(lastShownList, attendanceType);
+        try {
+            model.markAllStudents(lastShownList, attendanceType);
+        } catch (SessionException sessionException) {
+            throw new CommandException(sessionException.getMessage());
+        }
         return new CommandResult(String.format(MESSAGE_MARK_ALL_SUCCESS, attendanceType));
     }
 

--- a/src/main/java/seedu/taskmaster/logic/commands/MarkAllCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/MarkAllCommand.java
@@ -30,9 +30,7 @@ public class MarkAllCommand extends MarkCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
         List<Student> lastShownList = model.getFilteredStudentList();
-
         try {
             model.markAllStudents(lastShownList, attendanceType);
         } catch (SessionException sessionException) {

--- a/src/main/java/seedu/taskmaster/logic/commands/MarkAllCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/MarkAllCommand.java
@@ -8,7 +8,6 @@ import java.util.List;
 import seedu.taskmaster.logic.commands.exceptions.CommandException;
 import seedu.taskmaster.model.Model;
 import seedu.taskmaster.model.record.AttendanceType;
-import seedu.taskmaster.model.session.exceptions.NoSessionException;
 import seedu.taskmaster.model.session.exceptions.SessionException;
 import seedu.taskmaster.model.student.Student;
 

--- a/src/main/java/seedu/taskmaster/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/MarkCommand.java
@@ -52,7 +52,6 @@ public class MarkCommand extends Command {
         }
 
         Student studentToMark = lastShownList.get(index);
-
         try {
             model.markStudent(studentToMark, attendanceType);
         } catch (SessionException sessionException) {

--- a/src/main/java/seedu/taskmaster/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/MarkCommand.java
@@ -10,7 +10,6 @@ import seedu.taskmaster.commons.core.index.Index;
 import seedu.taskmaster.logic.commands.exceptions.CommandException;
 import seedu.taskmaster.model.Model;
 import seedu.taskmaster.model.record.AttendanceType;
-import seedu.taskmaster.model.session.exceptions.NoSessionException;
 import seedu.taskmaster.model.session.exceptions.SessionException;
 import seedu.taskmaster.model.student.Student;
 

--- a/src/main/java/seedu/taskmaster/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/MarkCommand.java
@@ -10,6 +10,8 @@ import seedu.taskmaster.commons.core.index.Index;
 import seedu.taskmaster.logic.commands.exceptions.CommandException;
 import seedu.taskmaster.model.Model;
 import seedu.taskmaster.model.record.AttendanceType;
+import seedu.taskmaster.model.session.exceptions.NoSessionException;
+import seedu.taskmaster.model.session.exceptions.SessionException;
 import seedu.taskmaster.model.student.Student;
 
 /**
@@ -50,7 +52,12 @@ public class MarkCommand extends Command {
         }
 
         Student studentToMark = lastShownList.get(index);
-        model.markStudent(studentToMark, attendanceType);
+
+        try {
+            model.markStudent(studentToMark, attendanceType);
+        } catch (SessionException sessionException) {
+            throw new CommandException(sessionException.getMessage());
+        }
         return new CommandResult(String.format(MESSAGE_MARK_STUDENT_SUCCESS, studentToMark, attendanceType));
     }
 

--- a/src/main/java/seedu/taskmaster/model/Model.java
+++ b/src/main/java/seedu/taskmaster/model/Model.java
@@ -61,6 +61,12 @@ public interface Model {
     /** Returns the Taskmaster */
     ReadOnlyTaskmaster getTaskmaster();
 
+    /**
+     * Replaces the contents of the session list with {@code sessions}.
+     * {@code sessions} must not contain duplicate sessions.
+     */
+    void setSessions(List<Session> sessions);
+
     void changeSession(SessionName sessionName);
 
     /**

--- a/src/main/java/seedu/taskmaster/model/ModelManager.java
+++ b/src/main/java/seedu/taskmaster/model/ModelManager.java
@@ -98,6 +98,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void setSessions(List<Session> sessions) {
+        taskmaster.setSessions(sessions);
+    }
+
+    @Override
     public void changeSession(SessionName sessionName) {
         taskmaster.changeSession(sessionName);
     }

--- a/src/main/java/seedu/taskmaster/model/Taskmaster.java
+++ b/src/main/java/seedu/taskmaster/model/Taskmaster.java
@@ -15,6 +15,8 @@ import seedu.taskmaster.model.session.SessionDateTime;
 import seedu.taskmaster.model.session.SessionList;
 import seedu.taskmaster.model.session.SessionListManager;
 import seedu.taskmaster.model.session.SessionName;
+import seedu.taskmaster.model.session.exceptions.NoSessionException;
+import seedu.taskmaster.model.session.exceptions.NoSessionSelectedException;
 import seedu.taskmaster.model.student.NusnetId;
 import seedu.taskmaster.model.student.Student;
 import seedu.taskmaster.model.student.UniqueStudentList;
@@ -40,17 +42,8 @@ public class Taskmaster implements ReadOnlyTaskmaster {
      */
     {
         students = new UniqueStudentList();
-
-        // TODO: Current session is a default placeholder for now
-        currentSession = new Session(
-                new SessionName("Default session"),
-                new SessionDateTime(LocalDateTime.now()),
-                StudentRecordListManager.of(students.asUnmodifiableObservableList()));
-
-        // TODO: For now, SessionList is initialised to a list with one default placeholder session
-        List<Session> sessionList = new ArrayList<>();
-        sessionList.add(currentSession);
-        sessions = SessionListManager.of(sessionList);
+        currentSession = null;
+        sessions = SessionListManager.of(new ArrayList<>());
     }
 
     public Taskmaster() {}
@@ -80,10 +73,7 @@ public class Taskmaster implements ReadOnlyTaskmaster {
     public void resetData(ReadOnlyTaskmaster newData) {
         requireNonNull(newData);
         setStudents(newData.getStudentList());
-        currentSession = new Session(
-                new SessionName("Placeholder session"),
-                new SessionDateTime(LocalDateTime.now()),
-                StudentRecordListManager.of(newData.getStudentList()));
+        currentSession = null;
     }
 
     /* Session-Level Operations */
@@ -160,34 +150,73 @@ public class Taskmaster implements ReadOnlyTaskmaster {
     }
 
     /**
-     * Marks the attendance of a {@code target} student with
-     * {@code attendanceType} in the current session.
+     * Marks the attendance of a {@code target} student with {@code attendanceType} in the current session.
+     *
+     * @throws NoSessionException If the session list is empty.
+     * @throws NoSessionSelectedException If no session has been selected.
      */
-    public void markStudent(Student target, AttendanceType attendanceType) {
+    public void markStudent(Student target, AttendanceType attendanceType)
+            throws NoSessionException, NoSessionSelectedException {
         assert target != null;
         assert attendanceType != null;
+
+        if (sessions.isEmpty()) {
+            throw new NoSessionException();
+        }
+
+        if (!sessions.isEmpty() && currentSession == null) {
+            throw new NoSessionSelectedException();
+        }
+
         currentSession.markStudentAttendance(target.getNusnetId(), attendanceType);
     }
 
     /**
      * Marks the attendance of a student given the {@code nusnetId}
      * with {@code attendanceType} in the current session.
+     *
+     * @throws NoSessionException If the session list is empty.
+     * @throws NoSessionSelectedException If no session has been selected.
      */
-    public void markStudentWithNusnetId(NusnetId nusnetId, AttendanceType attendanceType) {
+    public void markStudentWithNusnetId(NusnetId nusnetId, AttendanceType attendanceType)
+            throws NoSessionException, NoSessionSelectedException {
         assert nusnetId != null;
         assert attendanceType != null;
+
+        if (sessions.isEmpty()) {
+            throw new NoSessionException();
+        }
+
+        if (!sessions.isEmpty() && currentSession == null) {
+            throw new NoSessionSelectedException();
+        }
+
         currentSession.markStudentAttendance(nusnetId, attendanceType);
     }
 
     /**
      * Marks the attendance of all students represented by their {@code nusnetIds} in the {@code studentRecordList}
      * of the {@code currentSession}, with the given {@code attendanceType}.
+     *
+     * @throws NoSessionException If the session list is empty.
+     * @throws NoSessionSelectedException If no session has been selected.
      */
-    public void markAllStudents(List<NusnetId> nusnetIds, AttendanceType attendanceType) {
+    public void markAllStudents(List<NusnetId> nusnetIds, AttendanceType attendanceType)
+            throws NoSessionException, NoSessionSelectedException {
         assert nusnetIds != null;
         assert attendanceType != null;
+
+        if (sessions.isEmpty()) {
+            throw new NoSessionException();
+        }
+
+        if (!sessions.isEmpty() && currentSession == null) {
+            throw new NoSessionSelectedException();
+        }
+
         currentSession.markAllStudents(nusnetIds, attendanceType);
     }
+
     /* Util Methods */
 
     @Override
@@ -203,8 +232,20 @@ public class Taskmaster implements ReadOnlyTaskmaster {
 
     /**
      * Returns an unmodifiable view of the {@code StudentRecordList} of the current session.
+     *
+     * @throws NoSessionException If the session list is empty.
+     * @throws NoSessionSelectedException If no session has been selected.
      */
-    public ObservableList<StudentRecord> getStudentRecordList() {
+    public ObservableList<StudentRecord> getStudentRecordList()
+            throws NoSessionException, NoSessionSelectedException {
+        if (sessions.isEmpty()) {
+            throw new NoSessionException();
+        }
+
+        if (!sessions.isEmpty() && currentSession == null) {
+            throw new NoSessionSelectedException();
+        }
+
         return currentSession.getStudentRecords();
     }
 
@@ -215,16 +256,39 @@ public class Taskmaster implements ReadOnlyTaskmaster {
 
     /**
      * Sets the {@code AttendanceType} of all {@code StudentRecords} to NO_RECORD in the current session.
+     *
+     * @throws NoSessionException If the session list is empty.
+     * @throws NoSessionSelectedException If no session has been selected.
      */
-    public void clearAttendance() {
+    public void clearAttendance() throws NoSessionException, NoSessionSelectedException {
+        if (sessions.isEmpty()) {
+            throw new NoSessionException();
+        }
+
+        if (!sessions.isEmpty() && currentSession == null) {
+            throw new NoSessionSelectedException();
+        }
+
         currentSession.clearAttendance();
     }
 
     /**
      * Updates the {@code StudentRecordList} of the current session with the data in {@code studentRecords}.
-     * @throws StudentNotFoundException
+     *
+     * @throws StudentNotFoundException If the operation is unable to find the specified student.
+     * @throws NoSessionException If the session list is empty.
+     * @throws NoSessionSelectedException If no session has been selected.
      */
-    public void updateStudentRecords(List<StudentRecord> studentRecords) throws StudentNotFoundException {
+    public void updateStudentRecords(List<StudentRecord> studentRecords)
+            throws StudentNotFoundException, NoSessionException {
+        if (sessions.isEmpty()) {
+            throw new NoSessionException();
+        }
+
+        if (!sessions.isEmpty() && currentSession == null) {
+            throw new NoSessionSelectedException();
+        }
+
         currentSession.updateStudentRecords(studentRecords);
     }
 

--- a/src/main/java/seedu/taskmaster/model/Taskmaster.java
+++ b/src/main/java/seedu/taskmaster/model/Taskmaster.java
@@ -68,11 +68,20 @@ public class Taskmaster implements ReadOnlyTaskmaster {
     }
 
     /**
+     * Replaces the contents of the session list with {@code sessions}.
+     * {@code sessions} must not contain duplicate sessions.
+     */
+    public void setSessions(List<Session> sessions) {
+        this.sessions.setSessions(sessions);
+    }
+
+    /**
      * Resets the existing data of this {@code Taskmaster} with {@code newData}.
      */
     public void resetData(ReadOnlyTaskmaster newData) {
         requireNonNull(newData);
         setStudents(newData.getStudentList());
+        setSessions(newData.getSessionList());
         currentSession = null;
     }
 

--- a/src/main/java/seedu/taskmaster/model/Taskmaster.java
+++ b/src/main/java/seedu/taskmaster/model/Taskmaster.java
@@ -2,16 +2,13 @@ package seedu.taskmaster.model;
 
 import static java.util.Objects.requireNonNull;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.taskmaster.model.record.AttendanceType;
 import seedu.taskmaster.model.record.StudentRecord;
-import seedu.taskmaster.model.record.StudentRecordListManager;
 import seedu.taskmaster.model.session.Session;
-import seedu.taskmaster.model.session.SessionDateTime;
 import seedu.taskmaster.model.session.SessionList;
 import seedu.taskmaster.model.session.SessionListManager;
 import seedu.taskmaster.model.session.SessionName;

--- a/src/main/java/seedu/taskmaster/model/session/Session.java
+++ b/src/main/java/seedu/taskmaster/model/session/Session.java
@@ -7,7 +7,9 @@ import javafx.collections.ObservableList;
 import seedu.taskmaster.model.record.AttendanceType;
 import seedu.taskmaster.model.record.StudentRecord;
 import seedu.taskmaster.model.record.StudentRecordList;
+import seedu.taskmaster.model.record.StudentRecordListManager;
 import seedu.taskmaster.model.student.NusnetId;
+import seedu.taskmaster.model.student.Student;
 import seedu.taskmaster.model.student.exceptions.StudentNotFoundException;
 
 /**
@@ -31,6 +33,14 @@ public class Session {
         this.sessionName = sessionName;
         this.sessionDateTime = sessionDateTime;
         this.studentRecords = studentRecords;
+    }
+
+    public Session(SessionName sessionName,
+                   SessionDateTime sessionDateTime,
+                   List<Student> students) {
+        this.sessionName = sessionName;
+        this.sessionDateTime = sessionDateTime;
+        this.studentRecords = StudentRecordListManager.of(students);
     }
 
     public SessionName getSessionName() {

--- a/src/main/java/seedu/taskmaster/model/session/Session.java
+++ b/src/main/java/seedu/taskmaster/model/session/Session.java
@@ -35,6 +35,10 @@ public class Session {
         this.studentRecords = studentRecords;
     }
 
+    /**
+     * Creates a session object with a {@code sessionName}, {@code sessionDateTime} and
+     * a list of students.
+     */
     public Session(SessionName sessionName,
                    SessionDateTime sessionDateTime,
                    List<Student> students) {
@@ -111,6 +115,8 @@ public class Session {
             return false;
         }
         Session otherSession = (Session) other;
-        return otherSession.getSessionName().equals(getSessionName());
+        return otherSession.getSessionName().equals(getSessionName())
+                && otherSession.getSessionDateTime().equals(getSessionDateTime())
+                && otherSession.getStudentRecords().equals(getStudentRecords());
     }
 }

--- a/src/main/java/seedu/taskmaster/model/session/SessionList.java
+++ b/src/main/java/seedu/taskmaster/model/session/SessionList.java
@@ -20,6 +20,11 @@ public interface SessionList extends Iterable<Session> {
 
     int getNumberOfSessions();
 
+    /**
+     * Returns true if there are no sessions in the session list.
+     */
+    boolean isEmpty();
+
     void setSessions(SessionListManager replacement);
 
     /**

--- a/src/main/java/seedu/taskmaster/model/session/SessionListManager.java
+++ b/src/main/java/seedu/taskmaster/model/session/SessionListManager.java
@@ -63,6 +63,13 @@ public class SessionListManager implements SessionList {
         return false;
     }
 
+    /**
+     * Returns true if there are no sessions in the session list.
+     */
+    public boolean isEmpty() {
+        return getNumberOfSessions() == 0;
+    }
+
     @Override
     public void add(Session toAdd) {
         requireNonNull(toAdd);

--- a/src/main/java/seedu/taskmaster/model/session/exceptions/NoSessionException.java
+++ b/src/main/java/seedu/taskmaster/model/session/exceptions/NoSessionException.java
@@ -1,0 +1,16 @@
+package seedu.taskmaster.model.session.exceptions;
+
+/**
+ * Signals that the operation cannot be executed as the SessionList is empty.
+ */
+public class NoSessionException extends SessionException {
+
+    private final String message = "There are no sessions yet!";
+
+    public NoSessionException() {}
+
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/seedu/taskmaster/model/session/exceptions/NoSessionSelectedException.java
+++ b/src/main/java/seedu/taskmaster/model/session/exceptions/NoSessionSelectedException.java
@@ -1,0 +1,13 @@
+package seedu.taskmaster.model.session.exceptions;
+
+public class NoSessionSelectedException extends SessionException {
+
+    private final String message = "Please select a session first!";
+
+    public NoSessionSelectedException() {}
+
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/seedu/taskmaster/model/session/exceptions/SessionException.java
+++ b/src/main/java/seedu/taskmaster/model/session/exceptions/SessionException.java
@@ -1,0 +1,5 @@
+package seedu.taskmaster.model.session.exceptions;
+
+public abstract class SessionException extends RuntimeException {
+    public abstract String getMessage();
+}

--- a/src/main/java/seedu/taskmaster/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/taskmaster/model/util/SampleDataUtil.java
@@ -1,11 +1,15 @@
 package seedu.taskmaster.model.util;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.taskmaster.model.ReadOnlyTaskmaster;
 import seedu.taskmaster.model.Taskmaster;
+import seedu.taskmaster.model.session.Session;
+import seedu.taskmaster.model.session.SessionDateTime;
+import seedu.taskmaster.model.session.SessionName;
 import seedu.taskmaster.model.student.Email;
 import seedu.taskmaster.model.student.Name;
 import seedu.taskmaster.model.student.NusnetId;
@@ -17,35 +21,59 @@ import seedu.taskmaster.model.tag.Tag;
  * Contains utility methods for populating {@code Taskmaster} with sample data.
  */
 public class SampleDataUtil {
+
     public static Student[] getSampleStudents() {
         return new Student[] {
-            new Student(new Name("Alex Yeoh"), new Telegram("87438807"), new Email("alexyeoh@example.com"),
-                new NusnetId("e0456456"),
-                getTagSet("friends")),
-            new Student(new Name("Bernice Yu"), new Telegram("99272758"), new Email("berniceyu@example.com"),
-                new NusnetId("e0789789"),
-                getTagSet("colleagues", "friends")),
-            new Student(new Name("Charlotte Oliveiro"), new Telegram("93210283"), new Email("charlotte@example.com"),
-                new NusnetId("e0987897"),
-                getTagSet("neighbours")),
-            new Student(new Name("David Li"), new Telegram("91031282"), new Email("lidavid@example.com"),
-                new NusnetId("e0321321"),
-                getTagSet("family")),
-            new Student(new Name("Irfan Ibrahim"), new Telegram("92492021"), new Email("irfan@example.com"),
-                new NusnetId("e0984984"),
-                getTagSet("classmates")),
-            new Student(new Name("Roy Balakrishnan"), new Telegram("92624417"), new Email("royb@example.com"),
-                new NusnetId("e0984983"),
-                getTagSet("colleagues"))
+            new Student(
+                    new Name("Alex Yeoh"),
+                    new Telegram("87438807"),
+                    new Email("alexyeoh@example.com"),
+                    new NusnetId("e0456456"),
+                    getTagSet("friends")),
+            new Student(
+                    new Name("Bernice Yu"),
+                    new Telegram("99272758"),
+                    new Email("berniceyu@example.com"),
+                    new NusnetId("e0789789"),
+                    getTagSet("colleagues", "friends")),
+            new Student(
+                    new Name("Charlotte Oliveiro"),
+                    new Telegram("93210283"),
+                    new Email("charlotte@example.com"),
+                    new NusnetId("e0987897"),
+                    getTagSet("neighbours")),
+            new Student(
+                    new Name("David Li"),
+                    new Telegram("91031282"),
+                    new Email("lidavid@example.com"),
+                    new NusnetId("e0321321"),
+                    getTagSet("family")),
+            new Student(
+                    new Name("Irfan Ibrahim"),
+                    new Telegram("92492021"),
+                    new Email("irfan@example.com"),
+                    new NusnetId("e0984984"),
+                    getTagSet("classmates")),
+            new Student(
+                    new Name("Roy Balakrishnan"),
+                    new Telegram("92624417"),
+                    new Email("royb@example.com"),
+                    new NusnetId("e0984983"),
+                    getTagSet("colleagues"))
         };
     }
 
     public static ReadOnlyTaskmaster getSampleTaskmaster() {
-        Taskmaster sampleAb = new Taskmaster();
+        Taskmaster sampleTaskmaster = new Taskmaster();
         for (Student sampleStudent : getSampleStudents()) {
-            sampleAb.addStudent(sampleStudent);
+            sampleTaskmaster.addStudent(sampleStudent);
         }
-        return sampleAb;
+        Session sampleSession = new Session(
+                new SessionName("Sample session"),
+                new SessionDateTime(LocalDateTime.of(2020, 1,1,12,0)),
+                Arrays.asList(getSampleStudents()));
+        sampleTaskmaster.addSession(sampleSession);
+        return sampleTaskmaster;
     }
 
     /**

--- a/src/main/java/seedu/taskmaster/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/taskmaster/model/util/SampleDataUtil.java
@@ -70,7 +70,7 @@ public class SampleDataUtil {
         }
         Session sampleSession = new Session(
                 new SessionName("Sample session"),
-                new SessionDateTime(LocalDateTime.of(2020, 1,1,12,0)),
+                new SessionDateTime(LocalDateTime.of(2020, 1, 1, 12, 0)),
                 Arrays.asList(getSampleStudents()));
         sampleTaskmaster.addSession(sampleSession);
         return sampleTaskmaster;

--- a/src/test/java/seedu/taskmaster/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/AddCommandTest.java
@@ -135,6 +135,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setSessions(List<Session> sessions) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void changeSession(SessionName sessionName) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/taskmaster/logic/commands/MarkAllCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/MarkAllCommandTest.java
@@ -11,6 +11,7 @@ import seedu.taskmaster.model.Model;
 import seedu.taskmaster.model.ModelManager;
 import seedu.taskmaster.model.UserPrefs;
 import seedu.taskmaster.model.record.AttendanceType;
+import seedu.taskmaster.model.session.SessionName;
 import seedu.taskmaster.model.student.Student;
 
 public class MarkAllCommandTest {
@@ -18,9 +19,11 @@ public class MarkAllCommandTest {
 
     @Test
     public void execute_markAllStudentsAsPresent_success() {
+        model.changeSession(new SessionName("Typical session"));
         List<Student> students = model.getFilteredStudentList();
         MarkAllCommand markAllCommand = new MarkAllCommand(AttendanceType.PRESENT);
         Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
+        expectedModel.changeSession(new SessionName("Typical session"));
         expectedModel.markAllStudents(students, AttendanceType.PRESENT);
         String expectedMessage = String.format(MarkAllCommand.MESSAGE_MARK_ALL_SUCCESS, AttendanceType.PRESENT);
         assertCommandSuccess(markAllCommand, model, expectedMessage, expectedModel);
@@ -28,9 +31,11 @@ public class MarkAllCommandTest {
 
     @Test
     public void execute_markAllStudentsAsAbsent_success() {
+        model.changeSession(new SessionName("Typical session"));
         List<Student> students = model.getFilteredStudentList();
         MarkAllCommand markAllCommand = new MarkAllCommand(AttendanceType.ABSENT);
         Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
+        expectedModel.changeSession(new SessionName("Typical session"));
         expectedModel.markAllStudents(students, AttendanceType.ABSENT);
         String expectedMessage = String.format(MarkAllCommand.MESSAGE_MARK_ALL_SUCCESS, AttendanceType.ABSENT);
         assertCommandSuccess(markAllCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/taskmaster/logic/commands/MarkAllCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/MarkAllCommandTest.java
@@ -1,8 +1,10 @@
 package seedu.taskmaster.logic.commands;
 
+import static seedu.taskmaster.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.taskmaster.testutil.TypicalStudents.getTypicalTaskmaster;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -39,5 +41,20 @@ public class MarkAllCommandTest {
         expectedModel.markAllStudents(students, AttendanceType.ABSENT);
         String expectedMessage = String.format(MarkAllCommand.MESSAGE_MARK_ALL_SUCCESS, AttendanceType.ABSENT);
         assertCommandSuccess(markAllCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_emptySessionList_exceptionThrown() {
+        model.setSessions(new ArrayList<>());
+        MarkAllCommand markAllCommand = new MarkAllCommand(AttendanceType.PRESENT);
+        String expectedMessage = "There are no sessions yet!";
+        assertCommandFailure(markAllCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_nullCurrentSession_exceptionThrown() {
+        MarkAllCommand markAllCommand = new MarkAllCommand(AttendanceType.PRESENT);
+        String expectedMessage = "Please select a session first!";
+        assertCommandFailure(markAllCommand, model, expectedMessage);
     }
 }

--- a/src/test/java/seedu/taskmaster/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/MarkCommandTest.java
@@ -14,17 +14,21 @@ import seedu.taskmaster.model.Model;
 import seedu.taskmaster.model.ModelManager;
 import seedu.taskmaster.model.UserPrefs;
 import seedu.taskmaster.model.record.AttendanceType;
+import seedu.taskmaster.model.session.SessionName;
 import seedu.taskmaster.model.student.Student;
 
 
 public class MarkCommandTest {
+
     private Model model = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
 
     @Test
     public void execute_markPresentWithValidIndex_success() {
+        model.changeSession(new SessionName("Typical session"));
+        Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
+        expectedModel.changeSession(new SessionName("Typical session"));
         Student firstStudent = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
         MarkCommand markCommand = new MarkCommand(INDEX_FIRST_STUDENT, AttendanceType.PRESENT);
-        Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
         expectedModel.markStudent(firstStudent, AttendanceType.PRESENT);
         String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_STUDENT_SUCCESS,
                 firstStudent, AttendanceType.PRESENT);
@@ -35,7 +39,9 @@ public class MarkCommandTest {
     public void execute_markAbsentWithValidIndex_success() {
         Student secondStudent = model.getFilteredStudentList().get(INDEX_SECOND_STUDENT.getZeroBased());
         MarkCommand markCommand = new MarkCommand(INDEX_SECOND_STUDENT, AttendanceType.ABSENT);
+        model.changeSession(new SessionName("Typical session"));
         Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
+        expectedModel.changeSession(new SessionName("Typical session"));
         expectedModel.markStudent(secondStudent, AttendanceType.ABSENT);
         String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_STUDENT_SUCCESS,
                 secondStudent, AttendanceType.ABSENT);
@@ -44,6 +50,7 @@ public class MarkCommandTest {
 
     @Test
     public void execute_indexTooLarge_failure() {
+        model.changeSession(new SessionName("Typical session"));
         int numOfStudents = model.getFilteredStudentList().size();
         Index indexTooBig = Index.fromZeroBased(numOfStudents);
         MarkCommand markCommand = new MarkCommand(indexTooBig, AttendanceType.PRESENT);

--- a/src/test/java/seedu/taskmaster/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/MarkCommandTest.java
@@ -6,6 +6,8 @@ import static seedu.taskmaster.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 import static seedu.taskmaster.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
 import static seedu.taskmaster.testutil.TypicalStudents.getTypicalTaskmaster;
 
+import java.util.ArrayList;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.taskmaster.commons.core.Messages;
@@ -16,8 +18,6 @@ import seedu.taskmaster.model.UserPrefs;
 import seedu.taskmaster.model.record.AttendanceType;
 import seedu.taskmaster.model.session.SessionName;
 import seedu.taskmaster.model.student.Student;
-
-import java.util.ArrayList;
 
 
 public class MarkCommandTest {

--- a/src/test/java/seedu/taskmaster/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/MarkCommandTest.java
@@ -17,6 +17,8 @@ import seedu.taskmaster.model.record.AttendanceType;
 import seedu.taskmaster.model.session.SessionName;
 import seedu.taskmaster.model.student.Student;
 
+import java.util.ArrayList;
+
 
 public class MarkCommandTest {
 
@@ -56,4 +58,20 @@ public class MarkCommandTest {
         MarkCommand markCommand = new MarkCommand(indexTooBig, AttendanceType.PRESENT);
         assertCommandFailure(markCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
+
+    @Test
+    public void execute_emptySessionList_exceptionThrown() {
+        model.setSessions(new ArrayList<>());
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_STUDENT, AttendanceType.PRESENT);
+        String expectedMessage = "There are no sessions yet!";
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_nullCurrentSession_exceptionThrown() {
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_STUDENT, AttendanceType.PRESENT);
+        String expectedMessage = "Please select a session first!";
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
 }

--- a/src/test/java/seedu/taskmaster/logic/commands/StoreAttendanceCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/StoreAttendanceCommandTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.io.TempDir;
 import seedu.taskmaster.model.Model;
 import seedu.taskmaster.model.ModelManager;
 import seedu.taskmaster.model.UserPrefs;
+import seedu.taskmaster.model.session.SessionName;
 import seedu.taskmaster.storage.JsonTaskmasterStorage;
 import seedu.taskmaster.storage.JsonUserPrefsStorage;
 import seedu.taskmaster.storage.Storage;
@@ -33,7 +34,7 @@ public class StoreAttendanceCommandTest {
 
     @BeforeEach
     public void setUp() {
-        JsonTaskmasterStorage taskmasterStorage = new JsonTaskmasterStorage(getTempFilePath("ab"));
+        JsonTaskmasterStorage taskmasterStorage = new JsonTaskmasterStorage(getTempFilePath("tm"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
         storage = new StorageManager(taskmasterStorage, userPrefsStorage);
     }
@@ -57,6 +58,8 @@ public class StoreAttendanceCommandTest {
         assert(Files.exists(filepath));
         Model model = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
+        model.changeSession(new SessionName("Typical session"));
+        expectedModel.changeSession(new SessionName("Typical session"));
         StorageCommand storeCommand = new StoreAttendanceCommand(filename);
         storeCommand.initialiseStorage(storage);
         String successMessage = StoreAttendanceCommand.MESSAGE_SAVE_SUCCESS_OVERWRITE;
@@ -79,6 +82,8 @@ public class StoreAttendanceCommandTest {
         assert(!Files.exists(filepath));
         Model model = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
+        model.changeSession(new SessionName("Typical session"));
+        expectedModel.changeSession(new SessionName("Typical session"));
         StorageCommand storeCommand = new StoreAttendanceCommand(filename);
         storeCommand.initialiseStorage(storage);
         String successMessage = StoreAttendanceCommand.MESSAGE_SAVE_SUCCESS_NEWFILE;

--- a/src/test/java/seedu/taskmaster/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/taskmaster/testutil/TypicalStudents.java
@@ -11,6 +11,11 @@ import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_TELEGRAM_AMY;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_TELEGRAM_BOB;
 
+import seedu.taskmaster.model.session.Session;
+import seedu.taskmaster.model.session.SessionDateTime;
+import seedu.taskmaster.model.session.SessionName;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -23,36 +28,82 @@ import seedu.taskmaster.model.student.Student;
  */
 public class TypicalStudents {
 
-    public static final Student ALICE = new StudentBuilder().withName("Alice Pauline")
-            .withNusnetId("e0123456").withEmail("alice@example.com")
+    public static final Student ALICE =
+            new StudentBuilder()
+            .withName("Alice Pauline")
+            .withNusnetId("e0123456")
+            .withEmail("alice@example.com")
             .withTelegram("94351253")
             .withTags("friends").build();
-    public static final Student BENSON = new StudentBuilder().withName("Benson Meier")
+
+    public static final Student BENSON =
+            new StudentBuilder()
+            .withName("Benson Meier")
             .withNusnetId("e0456789")
-            .withEmail("johnd@example.com").withTelegram("98765432")
+            .withEmail("johnd@example.com")
+            .withTelegram("98765432")
             .withTags("owesMoney", "friends").build();
-    public static final Student CARL = new StudentBuilder().withName("Carl Kurz").withTelegram("95352563")
-            .withEmail("heinz@example.com").withNusnetId("e0312654").build();
-    public static final Student DANIEL = new StudentBuilder().withName("Daniel Meier").withTelegram("87652533")
-            .withEmail("cornelia@example.com").withNusnetId("e0987465").withTags("friends").build();
-    public static final Student ELLE = new StudentBuilder().withName("Elle Meyer").withTelegram("9482224")
-            .withEmail("werner@example.com").withNusnetId("e0946875").build();
-    public static final Student FIONA = new StudentBuilder().withName("Fiona Kunz").withTelegram("9482427")
-            .withEmail("lydia@example.com").withNusnetId("e0319843").build();
-    public static final Student GEORGE = new StudentBuilder().withName("George Best").withTelegram("9482442")
-            .withEmail("anna@example.com").withNusnetId("e0731894").build();
+
+    public static final Student CARL =
+            new StudentBuilder()
+                    .withName("Carl Kurz")
+                    .withTelegram("95352563")
+                    .withEmail("heinz@example.com")
+                    .withNusnetId("e0312654").build();
+
+    public static final Student DANIEL =
+            new StudentBuilder()
+                    .withName("Daniel Meier")
+                    .withTelegram("87652533")
+                    .withEmail("cornelia@example.com")
+                    .withNusnetId("e0987465")
+                    .withTags("friends").build();
+
+    public static final Student ELLE = new StudentBuilder()
+            .withName("Elle Meyer")
+            .withTelegram("9482224")
+            .withEmail("werner@example.com")
+            .withNusnetId("e0946875").build();
+
+    public static final Student FIONA = new StudentBuilder()
+            .withName("Fiona Kunz")
+            .withTelegram("9482427")
+            .withEmail("lydia@example.com")
+            .withNusnetId("e0319843").build();
+
+    public static final Student GEORGE = new StudentBuilder()
+            .withName("George Best")
+            .withTelegram("9482442")
+            .withEmail("anna@example.com")
+            .withNusnetId("e0731894").build();
 
     // Manually added
-    public static final Student HOON = new StudentBuilder().withName("Hoon Meier").withTelegram("8482424")
-            .withEmail("stefan@example.com").withNusnetId("e0134679").build();
-    public static final Student IDA = new StudentBuilder().withName("Ida Mueller").withTelegram("8482131")
-            .withEmail("hans@example.com").withNusnetId("e0235689").build();
+    public static final Student HOON = new StudentBuilder()
+            .withName("Hoon Meier")
+            .withTelegram("8482424")
+            .withEmail("stefan@example.com")
+            .withNusnetId("e0134679").build();
+
+    public static final Student IDA = new StudentBuilder()
+            .withName("Ida Mueller")
+            .withTelegram("8482131")
+            .withEmail("hans@example.com")
+            .withNusnetId("e0235689").build();
 
     // Manually added - Student's details found in {@code CommandTestUtil}
-    public static final Student AMY = new StudentBuilder().withName(VALID_NAME_AMY).withTelegram(VALID_TELEGRAM_AMY)
-            .withEmail(VALID_EMAIL_AMY).withNusnetId(VALID_NUSNETID_AMY).withTags(VALID_TAG_FRIEND).build();
-    public static final Student BOB = new StudentBuilder().withName(VALID_NAME_BOB).withTelegram(VALID_TELEGRAM_BOB)
-            .withEmail(VALID_EMAIL_BOB).withNusnetId(VALID_NUSNETID_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+    public static final Student AMY = new StudentBuilder().
+            withName(VALID_NAME_AMY)
+            .withTelegram(VALID_TELEGRAM_AMY)
+            .withEmail(VALID_EMAIL_AMY)
+            .withNusnetId(VALID_NUSNETID_AMY)
+            .withTags(VALID_TAG_FRIEND).build();
+
+    public static final Student BOB = new StudentBuilder()
+            .withName(VALID_NAME_BOB)
+            .withTelegram(VALID_TELEGRAM_BOB)
+            .withEmail(VALID_EMAIL_BOB)
+            .withNusnetId(VALID_NUSNETID_BOB)
+            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
@@ -63,11 +114,16 @@ public class TypicalStudents {
      * Returns an {@code Taskmaster} with all the typical students.
      */
     public static Taskmaster getTypicalTaskmaster() {
-        Taskmaster ab = new Taskmaster();
+        Taskmaster typicalTaskmaster = new Taskmaster();
         for (Student student : getTypicalStudents()) {
-            ab.addStudent(student);
+            typicalTaskmaster.addStudent(student);
         }
-        return ab;
+        Session typicalSession = new Session(
+                new SessionName("Typical session"),
+                new SessionDateTime(LocalDateTime.of(2020, 1,1,12,0)),
+                getTypicalStudents());
+        typicalTaskmaster.addSession(typicalSession);
+        return typicalTaskmaster;
     }
 
     public static List<Student> getTypicalStudents() {

--- a/src/test/java/seedu/taskmaster/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/taskmaster/testutil/TypicalStudents.java
@@ -11,16 +11,15 @@ import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_TELEGRAM_AMY;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_TELEGRAM_BOB;
 
-import seedu.taskmaster.model.session.Session;
-import seedu.taskmaster.model.session.SessionDateTime;
-import seedu.taskmaster.model.session.SessionName;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import seedu.taskmaster.model.Taskmaster;
+import seedu.taskmaster.model.session.Session;
+import seedu.taskmaster.model.session.SessionDateTime;
+import seedu.taskmaster.model.session.SessionName;
 import seedu.taskmaster.model.student.Student;
 
 /**
@@ -91,8 +90,8 @@ public class TypicalStudents {
             .withNusnetId("e0235689").build();
 
     // Manually added - Student's details found in {@code CommandTestUtil}
-    public static final Student AMY = new StudentBuilder().
-            withName(VALID_NAME_AMY)
+    public static final Student AMY = new StudentBuilder()
+            .withName(VALID_NAME_AMY)
             .withTelegram(VALID_TELEGRAM_AMY)
             .withEmail(VALID_EMAIL_AMY)
             .withNusnetId(VALID_NUSNETID_AMY)
@@ -120,7 +119,7 @@ public class TypicalStudents {
         }
         Session typicalSession = new Session(
                 new SessionName("Typical session"),
-                new SessionDateTime(LocalDateTime.of(2020, 1,1,12,0)),
+                new SessionDateTime(LocalDateTime.of(2020, 1, 1, 12, 0)),
                 getTypicalStudents());
         typicalTaskmaster.addSession(typicalSession);
         return typicalTaskmaster;


### PR DESCRIPTION
# Set initial SessionList to be empty and initial currentSession as null

## Summary
When TAskmaster starts up, instead of creating a default session, it creates an empty session list and initializes the current session as null instead. I have also implemented a SessionException to handle cases where a `mark` command or `mark all` command is executed before a session is created or selected. I have also updated the UG accordingly.
Closes #99

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
