### PR TITLE
Fix bug with mark all not correctly marking all records

### DIFF
--- a/src/main/java/seedu/taskmaster/logic/commands/MarkAllCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/MarkAllCommand.java
@@ -8,8 +8,8 @@ import java.util.List;
 import seedu.taskmaster.logic.commands.exceptions.CommandException;
 import seedu.taskmaster.model.Model;
 import seedu.taskmaster.model.record.AttendanceType;
+import seedu.taskmaster.model.record.StudentRecord;
 import seedu.taskmaster.model.session.exceptions.SessionException;
-import seedu.taskmaster.model.student.Student;
 
 public class MarkAllCommand extends MarkCommand {
     public static final String COMMAND_WORD = "mark all";
@@ -29,9 +29,9 @@ public class MarkAllCommand extends MarkCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Student> lastShownList = model.getFilteredStudentList();
         try {
-            model.markAllStudents(lastShownList, attendanceType);
+            List<StudentRecord> lastShownList = model.getFilteredStudentRecordList();
+            model.markAllStudentRecords(lastShownList, attendanceType);
         } catch (SessionException sessionException) {
             throw new CommandException(sessionException.getMessage());
         }

--- a/src/main/java/seedu/taskmaster/model/Model.java
+++ b/src/main/java/seedu/taskmaster/model/Model.java
@@ -137,9 +137,9 @@ public interface Model {
     void markStudentWithNusnetId(NusnetId nusnetId, AttendanceType attendanceType);
 
     /**
-     * Marks the attendances of all {@code students} with the given {@code attendanceType}
+     * Marks the attendances of all {@code studentRecords} with the given {@code attendanceType}
      */
-    void markAllStudents(List<Student> students, AttendanceType attendanceType);
+    void markAllStudentRecords(List<StudentRecord> studentRecords, AttendanceType attendanceType);
 
     /**
      * Marks the attendance of the given student {@code target} with the given {@code attendanceType}.

--- a/src/main/java/seedu/taskmaster/model/ModelManager.java
+++ b/src/main/java/seedu/taskmaster/model/ModelManager.java
@@ -190,13 +190,13 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void markAllStudents(List<Student> students, AttendanceType attendanceType) {
-        List<NusnetId> nusnetIds = students
+    public void markAllStudentRecords(List<StudentRecord> studentRecords, AttendanceType attendanceType) {
+        List<NusnetId> nusnetIds = studentRecords
                 .stream()
-                .map(Student::getNusnetId)
+                .map(StudentRecord::getNusnetId)
                 .collect(Collectors.toList());
 
-        taskmaster.markAllStudents(nusnetIds, attendanceType);
+        taskmaster.markAllStudentRecords(nusnetIds, attendanceType);
     }
 
     @Override

--- a/src/main/java/seedu/taskmaster/model/Taskmaster.java
+++ b/src/main/java/seedu/taskmaster/model/Taskmaster.java
@@ -204,13 +204,13 @@ public class Taskmaster implements ReadOnlyTaskmaster {
     }
 
     /**
-     * Marks the attendance of all students represented by their {@code nusnetIds} in the {@code studentRecordList}
+     * Marks the attendance of all student records represented by {@code nusnetIds} in the {@code studentRecordList}
      * of the {@code currentSession}, with the given {@code attendanceType}.
      *
      * @throws NoSessionException If the session list is empty.
      * @throws NoSessionSelectedException If no session has been selected.
      */
-    public void markAllStudents(List<NusnetId> nusnetIds, AttendanceType attendanceType)
+    public void markAllStudentRecords(List<NusnetId> nusnetIds, AttendanceType attendanceType)
             throws NoSessionException, NoSessionSelectedException {
         assert nusnetIds != null;
         assert attendanceType != null;
@@ -223,7 +223,7 @@ public class Taskmaster implements ReadOnlyTaskmaster {
             throw new NoSessionSelectedException();
         }
 
-        currentSession.get().markAllStudents(nusnetIds, attendanceType);
+        currentSession.get().markAllStudentAttendances(nusnetIds, attendanceType);
     }
 
     /**

--- a/src/main/java/seedu/taskmaster/model/record/StudentRecordList.java
+++ b/src/main/java/seedu/taskmaster/model/record/StudentRecordList.java
@@ -16,7 +16,7 @@ public interface StudentRecordList extends Iterable<StudentRecord> {
     /**
      * Marks the attendance of students represented by the list of {@code nusnetIds} with {@code attendanceType}.
      */
-    void markAllStudents(List<NusnetId> nusnetIds, AttendanceType attendanceType);
+    void markAllStudentAttendances(List<NusnetId> nusnetIds, AttendanceType attendanceType);
 
     /**
      * Updates participation score of a student represented by their {@code nusnetId} to {@code score}.

--- a/src/main/java/seedu/taskmaster/model/record/StudentRecordListManager.java
+++ b/src/main/java/seedu/taskmaster/model/record/StudentRecordListManager.java
@@ -70,7 +70,7 @@ public class StudentRecordListManager implements StudentRecordList {
      * Marks the attendance of students represented by the list of {@code nusnetIds} with {@code attendanceType}.
      */
     @Override
-    public void markAllStudents(List<NusnetId> nusnetIds, AttendanceType attendanceType) {
+    public void markAllStudentAttendances(List<NusnetId> nusnetIds, AttendanceType attendanceType) {
         for (NusnetId nusnetId : nusnetIds) {
             markStudentAttendance(nusnetId, attendanceType);
         }

--- a/src/main/java/seedu/taskmaster/model/session/Session.java
+++ b/src/main/java/seedu/taskmaster/model/session/Session.java
@@ -72,8 +72,8 @@ public class Session {
         studentRecords.markStudentAttendance(nusnetId, attendanceType);
     }
 
-    public void markAllStudents(List<NusnetId> nusnetIds, AttendanceType attendanceType) {
-        studentRecords.markAllStudents(nusnetIds, attendanceType);
+    public void markAllStudentAttendances(List<NusnetId> nusnetIds, AttendanceType attendanceType) {
+        studentRecords.markAllStudentAttendances(nusnetIds, attendanceType);
     }
 
     /**
@@ -93,7 +93,7 @@ public class Session {
      * Sets the {@code AttendanceType} of all {@code StudentRecords} to NO_RECORD.
      */
     public void clearAttendance() {
-        studentRecords.markAllStudents(
+        studentRecords.markAllStudentAttendances(
                 studentRecords.asUnmodifiableObservableList().stream()
                         .map(StudentRecord::getNusnetId).collect(Collectors.toList()),
                 AttendanceType.NO_RECORD);

--- a/src/test/java/seedu/taskmaster/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/AddCommandTest.java
@@ -207,7 +207,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void markAllStudents(List<Student> students, AttendanceType attendanceType) {
+        public void markAllStudentRecords(List<StudentRecord> studentRecords, AttendanceType attendanceType) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/taskmaster/logic/commands/MarkAllCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/MarkAllCommandTest.java
@@ -13,8 +13,8 @@ import seedu.taskmaster.model.Model;
 import seedu.taskmaster.model.ModelManager;
 import seedu.taskmaster.model.UserPrefs;
 import seedu.taskmaster.model.record.AttendanceType;
+import seedu.taskmaster.model.record.StudentRecord;
 import seedu.taskmaster.model.session.SessionName;
-import seedu.taskmaster.model.student.Student;
 
 public class MarkAllCommandTest {
     private Model model = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
@@ -22,11 +22,11 @@ public class MarkAllCommandTest {
     @Test
     public void execute_markAllStudentsAsPresent_success() {
         model.changeSession(new SessionName("Typical session"));
-        List<Student> students = model.getFilteredStudentList();
+        List<StudentRecord> studentRecords = model.getFilteredStudentRecordList();
         MarkAllCommand markAllCommand = new MarkAllCommand(AttendanceType.PRESENT);
         Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
         expectedModel.changeSession(new SessionName("Typical session"));
-        expectedModel.markAllStudents(students, AttendanceType.PRESENT);
+        expectedModel.markAllStudentRecords(studentRecords, AttendanceType.PRESENT);
         String expectedMessage = String.format(MarkAllCommand.MESSAGE_MARK_ALL_SUCCESS, AttendanceType.PRESENT);
         assertCommandSuccess(markAllCommand, model, expectedMessage, expectedModel);
     }
@@ -34,11 +34,11 @@ public class MarkAllCommandTest {
     @Test
     public void execute_markAllStudentsAsAbsent_success() {
         model.changeSession(new SessionName("Typical session"));
-        List<Student> students = model.getFilteredStudentList();
+        List<StudentRecord> studentRecords = model.getFilteredStudentRecordList();
         MarkAllCommand markAllCommand = new MarkAllCommand(AttendanceType.ABSENT);
         Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
         expectedModel.changeSession(new SessionName("Typical session"));
-        expectedModel.markAllStudents(students, AttendanceType.ABSENT);
+        expectedModel.markAllStudentRecords(studentRecords, AttendanceType.ABSENT);
         String expectedMessage = String.format(MarkAllCommand.MESSAGE_MARK_ALL_SUCCESS, AttendanceType.ABSENT);
         assertCommandSuccess(markAllCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/taskmaster/model/ModelManagerTest.java
+++ b/src/test/java/seedu/taskmaster/model/ModelManagerTest.java
@@ -7,6 +7,7 @@ import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_INT;
 import static seedu.taskmaster.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 import static seedu.taskmaster.testutil.Assert.assertThrows;
 import static seedu.taskmaster.testutil.TypicalStudentRecords.ALICE_STUDENT_RECORD;
+import static seedu.taskmaster.testutil.TypicalStudentRecords.BENSON_STUDENT_RECORD;
 import static seedu.taskmaster.testutil.TypicalStudents.ALICE;
 import static seedu.taskmaster.testutil.TypicalStudents.BENSON;
 import static seedu.taskmaster.testutil.TypicalStudents.BOB;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.taskmaster.commons.core.GuiSettings;
 import seedu.taskmaster.model.record.AttendanceType;
+import seedu.taskmaster.model.record.StudentRecord;
 import seedu.taskmaster.model.session.Session;
 import seedu.taskmaster.model.session.SessionDateTime;
 import seedu.taskmaster.model.session.SessionName;
@@ -405,18 +407,21 @@ public class ModelManagerTest {
         SessionName sName = new SessionName("Test Session");
         ArrayList<Student> stds = new ArrayList<Student>();
         stds.add(ALICE);
-        stds.add(BOB);
+        stds.add(BENSON);
+        ArrayList<StudentRecord> studentRecords = new ArrayList<>();
+        studentRecords.add(ALICE_STUDENT_RECORD);
+        studentRecords.add(BENSON_STUDENT_RECORD);
         Session s = new Session(sName,
                 new SessionDateTime(LocalDateTime.now()),
                 stds);
         modelManager.addSession(s);
         modelManager.changeSession(sName);
-        modelManager.markAllStudents(stds, AttendanceType.PRESENT);
+        modelManager.markAllStudentRecords(studentRecords, AttendanceType.PRESENT);
 
         assertTrue(s.getStudentRecords().toString()
                 .equals("[e0123456|PRESENT|Class Participation Score: 0,"
                         + " e0456789|PRESENT|Class Participation Score: 0]"));
-        modelManager.markAllStudents(stds, AttendanceType.ABSENT);
+        modelManager.markAllStudentRecords(studentRecords, AttendanceType.ABSENT);
         assertTrue(s.getStudentRecords().toString()
                 .equals("[e0123456|ABSENT|Class Participation Score: 0,"
                         + " e0456789|ABSENT|Class Participation Score: 0]"));
@@ -426,8 +431,12 @@ public class ModelManagerTest {
     void markAllStudents_noSession_failure() {
         ArrayList<Student> stds = new ArrayList<Student>();
         stds.add(ALICE);
-        stds.add(BOB);
-        assertThrows(NoSessionException.class, () -> modelManager.markAllStudents(stds, AttendanceType.PRESENT));
+        stds.add(BENSON);
+        ArrayList<StudentRecord> studentRecords = new ArrayList<>();
+        studentRecords.add(ALICE_STUDENT_RECORD);
+        studentRecords.add(BENSON_STUDENT_RECORD);
+        assertThrows(NoSessionException.class, () ->
+                modelManager.markAllStudentRecords(studentRecords, AttendanceType.PRESENT));
     }
 
     @Test
@@ -435,12 +444,15 @@ public class ModelManagerTest {
         SessionName sName = new SessionName("Test Session");
         ArrayList<Student> stds = new ArrayList<Student>();
         stds.add(ALICE);
-        stds.add(BOB);
+        stds.add(BENSON);
+        ArrayList<StudentRecord> studentRecords = new ArrayList<>();
+        studentRecords.add(ALICE_STUDENT_RECORD);
+        studentRecords.add(BENSON_STUDENT_RECORD);
         Session s = new Session(sName,
                 new SessionDateTime(LocalDateTime.now()),
                 stds);
         modelManager.addSession(s);
         assertThrows(NoSessionSelectedException.class, () -> modelManager
-                .markAllStudents(stds, AttendanceType.PRESENT));
+                .markAllStudentRecords(studentRecords, AttendanceType.PRESENT));
     }
 }

--- a/src/test/java/seedu/taskmaster/model/record/StudentRecordListTest.java
+++ b/src/test/java/seedu/taskmaster/model/record/StudentRecordListTest.java
@@ -45,7 +45,7 @@ public class StudentRecordListTest {
 
     @Test
     public void markAllStudents_idsInList_success() {
-        studentRecordList.markAllStudents(
+        studentRecordList.markAllStudentAttendances(
                 Collections.singletonList(studentInList.getNusnetId()), AttendanceType.PRESENT);
 
         List<StudentRecord> expectedStudentRecords =
@@ -63,7 +63,7 @@ public class StudentRecordListTest {
     @Test
     public void markAllStudents_idsNotInList_failure() {
         assertThrows(StudentNotFoundException.class, ()
-            -> studentRecordList.markAllStudents(
+            -> studentRecordList.markAllStudentAttendances(
                     Collections.singletonList(studentNotInList.getNusnetId()), AttendanceType.PRESENT));
     }
 


### PR DESCRIPTION
# Fix bug with mark all not correctly marking all records

## Summary
Bug: If you create a session, and then delete a student, and then run a mark all attendance, all students except for the deleted student in the session is marked.

This PR fixes said bug.

## Type of change
<Select all that apply, in the form [x]>
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
