### PR TITLE
Rename commands to differentiate session and student-related commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -17,6 +17,7 @@ TAskmaster is a **desktop app for managing students, optimised for use via a Com
     - [Editing a student: `edit-student`](#editing-a-student-edit-student "Go to Editing a student")
     - [Deleting a student: `delete-student`](#deleting-a-student-delete-student "Go to Deleting a student")
     - [Adding a session: `add-session`](#adding-a-session-add-session "Go to Adding a session")
+    - [Delete a session: `delete-session`](#delete-a-session-delete-session "Go to Deleting a session")
     - [Changing the current session: `goto`](#changing-the-current-session-goto "Go to Changing the current session")
     - [Marking a student's attendance: `mark`](#marking-a-students-attendance-mark "Go to Marking a student's attendance")
     - [Marking all students' attendance: `mark all`](#marking-all-students-attendance-mark-all "Go to Marking all students' attendance")
@@ -42,7 +43,8 @@ TAskmaster is a **desktop app for managing students, optimised for use via a Com
 2. Create a new session that represents a tutorial, lab or recitation session using the `add-session` command.
     * This session will read your student list and create a list of corresponding student records belonging to that session
     * Each student in the student list will be represented by a student record
-    * This list of records, once created, will be **independent of the student list**. Any modifications to the student list after a session is created **will not** affect the student records in that session. 
+    * This list of records, once created, will be **independent of the student list**. Any modifications to the student list after a session is created **will not** affect the student records in that session.
+    * You can use the `delete-session` command to delete a session from the session list.
 3. Mark your students' attendance and award them class participation marks with the `mark` and `score` commands respectively.
     * Note that you will not be allowed to use these commands outside of a session.
 
@@ -151,6 +153,19 @@ add-session s/SESSION_NAME dt/SESSION_DATE_TIME
 Example usage:
 ```
 add-session s/CS2103 Tutorial 9 dt/23-10-2020 0900
+```
+
+### Deleting a session: `delete-session`
+Deletes the specified session from the session list.
+```
+delete-session s/SESSION_NAME
+```
+- Deletes the session with the specified `SESSION_NAME` from the displayed session list.
+- A session with `SESSION_NAME` must exist in said list.
+
+Example usage:
+```
+delete-session s/CS2103 Tutorial 9
 ```
 
 ### Changing the current session: `goto`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -11,12 +11,12 @@ TAskmaster is a **desktop app for managing students, optimised for use via a Com
     - [Usage](#usage "Go to Usage")
 - [UI](#ui "Go to UI")
 - [Commands](#commands "Go to Commands")
-    - [Adding a student: `add`](#adding-a-student-add "Go to Adding a student")
+    - [Adding a student: `add-student`](#adding-a-student-add-student "Go to Adding a student")
     - [Listing all students: `list`](#listing-all-students-list "Go to Listing all students")
     - [Finding students by name: `find`](#finding-students-by-name-find "Go to Finding students by name")
-    - [Editing a student: `edit`](#editing-a-student-edit "Go to Editing a student")
-    - [Deleting a student: `delete`](#deleting-a-student-delete "Go to Deleting a student")
-    - [Adding a session: `session`](#adding-a-session-session "Go to Adding a session")
+    - [Editing a student: `edit-student`](#editing-a-student-edit-student "Go to Editing a student")
+    - [Deleting a student: `delete-student`](#deleting-a-student-delete-student "Go to Deleting a student")
+    - [Adding a session: `add-session`](#adding-a-session-add-session "Go to Adding a session")
     - [Changing the current session: `goto`](#changing-the-current-session-goto "Go to Changing the current session")
     - [Marking a student's attendance: `mark`](#marking-a-students-attendance-mark "Go to Marking a student's attendance")
     - [Marking all students' attendance: `mark all`](#marking-all-students-attendance-mark-all "Go to Marking all students' attendance")
@@ -37,9 +37,9 @@ TAskmaster is a **desktop app for managing students, optimised for use via a Com
 4. Double-click the file to start the app. A GUI should appear, with the field bar to input commands. The list of commands are available below.
 
 ### Usage
-1. Add the students that you are currently teaching into TAskmaster using the `add` command.
-    * You can use the `list`, `edit` and `delete` commands to read and modify your student list.
-2. Create a new session that represents a tutorial, lab or recitation session using the `session` command.
+1. Add the students that you are currently teaching into TAskmaster using the `add-student` command.
+    * You can use the `list`, `edit-student` and `delete-student` commands to read and modify your student list.
+2. Create a new session that represents a tutorial, lab or recitation session using the `add-session` command.
     * This session will read your student list and create a list of corresponding student records belonging to that session
     * Each student in the student list will be represented by a student record
     * This list of records, once created, will be **independent of the student list**. Any modifications to the student list after a session is created **will not** affect the student records in that session. 
@@ -65,10 +65,10 @@ The number below the attendance of the student is their current class participat
 > - Items with ellipses (`...`) after them can be used multiple times including zero times
 > - Parameters can be in any order
 
-### Adding a student: `add`
+### Adding a student: `add-student`
 Adds a student into the student list.
 ```
-add n/NAME u/TELEGRAM e/EMAIL i/NUSNETID [t/TAG]...
+add-student n/NAME u/TELEGRAM e/EMAIL i/NUSNETID [t/TAG]...
 ```
 - The `NAME` must be non-empty.
 - The `TELEGRAM` handle must be a valid handle (comprising only alphanumeric characters and underscores with length between 5 and 32 characters inclusive).
@@ -76,7 +76,7 @@ add n/NAME u/TELEGRAM e/EMAIL i/NUSNETID [t/TAG]...
 
 Example usage:
 ```
-add n/John Tan u/johntan98 e/johntan98@gmail.com i/e0012345 t/tardy
+add-student n/John Tan u/johntan98 e/johntan98@gmail.com i/e0012345 t/tardy
 ```
 
 ### Listing all students: `list`
@@ -105,10 +105,10 @@ find John
 find alex david
 ```
 
-### Editing a student: `edit`
+### Editing a student: `edit-student`
 Edits an existing student in the student list.
 ```
-edit INDEX [n/NAME] [u/TELEGRAM] [e/EMAIL] [i/NUSNETID] [t/TAG]...
+edit-student INDEX [n/NAME] [u/TELEGRAM] [e/EMAIL] [i/NUSNETID] [t/TAG]...
 ```
 - Edits the student at the specified `INDEX` number shown in the displayed student list. 
 - The `INDEX` **must be a positive integer** that exists in said list.
@@ -120,29 +120,29 @@ edit INDEX [n/NAME] [u/TELEGRAM] [e/EMAIL] [i/NUSNETID] [t/TAG]...
 Example usages:
 ```
 // Edit the telegram and email of the first person
-edit 1 u/johntan98 e/johntan98@gmail.com
+edit-student 1 u/johntan98 e/johntan98@gmail.com
 
 // Edit the name of the second person and clear all existing tags
-edit 2 n/Rachel Lee t/
+edit-student 2 n/Rachel Lee t/
 ```
 
-### Deleting a student: `delete`
+### Deleting a student: `delete-student`
 Deletes the specified student from the student list.
 ```
-delete INDEX
+delete-student INDEX
 ```
 - Deletes the student at the specified `INDEX` number shown in the displayed student list.
 - The `INDEX` **must be a positive integer** that exists in said list.
 
 Example usage:
 ```
-delete 3
+delete-student 3
 ```
 
-### Adding a session: `session`
+### Adding a session: `add-session`
 Adds a session into the session list.
 ```
-session s/SESSION_NAME dt/SESSION_DATE_TIME
+add-session s/SESSION_NAME dt/SESSION_DATE_TIME
 ```
 - The `SESSION_DATE_TIME` must be of the format `dd-MM-yyyy HHmm`.
 - The `SESSION_DATE_TIME` must be a valid date of the format `dd-MM-yyyy HHmm`.
@@ -150,7 +150,7 @@ session s/SESSION_NAME dt/SESSION_DATE_TIME
 
 Example usage:
 ```
-session s/CS2103 Tutorial 9 dt/23-10-2020 0900
+add-session s/CS2103 Tutorial 9 dt/23-10-2020 0900
 ```
 
 ### Changing the current session: `goto`
@@ -239,12 +239,12 @@ exit
 
 | Action            | Format, Examples                                                                                              |
 |-------------------|---------------------------------------------------------------------------------------------------------------|
-| Add student       | ```add n/NAME u/TELEGRAM e/EMAIL i/NUSNETID [t/TAG]``` <br> e.g., ```add n/John Tan u/johntan98```<br>```e/johntan98@gmail.com i/e0012345 t/tardy```  |
+| Add student       | ```add-student n/NAME u/TELEGRAM e/EMAIL i/NUSNETID [t/TAG]``` <br> e.g., ```add-student n/John Tan u/johntan98```<br>```e/johntan98@gmail.com i/e0012345 t/tardy```  |
 | List students     | ```list```                                                                                               |
 | Find students     | ```find KEYWORD [MORE_KEYWORDS]``` <br> e.g., ```find alex david```                                      |
-| Edit student      | ```edit INDEX [n/NAME] [u/TELEGRAM] [e/EMAIL] [i/NUSNETID] [t/TAG]...```<br> e.g., ```edit 1 u/johntan98 e/johntan98@gmail.com```                                                           |
-| Delete student    | ```delete INDEX``` <br> e.g., ```delete 3```                                                             |
-| Add session       | ```session s/SESSION_NAME dt/SESSION_DATE_TIME``` <br> e.g., ```session s/CS2103 Tutorial 9 dt/23-10-2020 0900```|
+| Edit student      | ```edit-student INDEX [n/NAME] [u/TELEGRAM] [e/EMAIL] [i/NUSNETID] [t/TAG]...```<br> e.g., ```edit-student 1 u/johntan98 e/johntan98@gmail.com```                                                           |
+| Delete student    | ```delete-student INDEX``` <br> e.g., ```delete-student 3```                                                             |
+| Add session       | ```add-session s/SESSION_NAME dt/SESSION_DATE_TIME``` <br> e.g., ```add-session s/CS2103 Tutorial 9 dt/23-10-2020 0900```|
 | Change session    | ```goto s/SESSION_NAME``` <br> e.g., ```goto s/CS2103 Tutorial 9```
 | Mark              | ```mark INDEX a/ATTENDANCE_TYPE``` <br> e.g., `mark 1 a/absent`                                             |
 | Mark all          | ```mark all a/ATTENDANCE_TYPE``` <br> e.g., `mark all a/present`

--- a/src/main/java/seedu/taskmaster/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/AddCommand.java
@@ -16,7 +16,7 @@ import seedu.taskmaster.model.student.Student;
  */
 public class AddCommand extends Command {
 
-    public static final String COMMAND_WORD = "add";
+    public static final String COMMAND_WORD = "add-student";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a student to the student list. "
             + "Parameters: "

--- a/src/main/java/seedu/taskmaster/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/DeleteCommand.java
@@ -15,7 +15,7 @@ import seedu.taskmaster.model.student.Student;
  */
 public class DeleteCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete";
+    public static final String COMMAND_WORD = "delete-student";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the student identified by the index number used in the displayed student list.\n"

--- a/src/main/java/seedu/taskmaster/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/EditCommand.java
@@ -31,7 +31,7 @@ import seedu.taskmaster.model.tag.Tag;
  */
 public class EditCommand extends Command {
 
-    public static final String COMMAND_WORD = "edit";
+    public static final String COMMAND_WORD = "edit-student";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the student identified "
             + "by the index number used in the displayed student list. "

--- a/src/main/java/seedu/taskmaster/logic/commands/NewSessionCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/NewSessionCommand.java
@@ -16,7 +16,7 @@ import seedu.taskmaster.model.session.SessionName;
  */
 public class NewSessionCommand extends Command {
 
-    public static final String COMMAND_WORD = "session";
+    public static final String COMMAND_WORD = "add-session";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a session to the session list. "
             + "Parameters: "

--- a/src/test/java/seedu/taskmaster/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/taskmaster/logic/LogicManagerTest.java
@@ -59,7 +59,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
+        String deleteCommand = "delete-student 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
 

--- a/src/test/java/seedu/taskmaster/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/CommandTestUtil.java
@@ -7,6 +7,8 @@ import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_CLASS_PARTICIPATION
 import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_NUSNETID;
+import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_SESSION_DATE_TIME;
+import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_SESSION_NAME;
 import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 import static seedu.taskmaster.testutil.Assert.assertThrows;
@@ -38,6 +40,8 @@ public class CommandTestUtil {
     public static final String VALID_NUSNETID_BOB = "e0456789";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_SESSION_NAME = "Tutorial 1";
+    public static final String VALID_SESSION_DATETIME = "23-10-2020 0900";
     public static final String PRESENT_ATTENDANCE = "present";
     public static final String ABSENT_ATTENDANCE = "absent";
     public static final String VALID_SCORE_STRING = "0";
@@ -55,6 +59,8 @@ public class CommandTestUtil {
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String ATTENDANCE_DESC_PRESENT = " " + PREFIX_ATTENDANCE_TYPE + PRESENT_ATTENDANCE;
     public static final String ATTENDANCE_DESC_ABSENT = " " + PREFIX_ATTENDANCE_TYPE + ABSENT_ATTENDANCE;
+    public static final String NEW_SESSION_NAME_DESC = " " + PREFIX_SESSION_NAME + VALID_SESSION_NAME;
+    public static final String NEW_SESSION_DATETIME_DESC = " " + PREFIX_SESSION_DATE_TIME + VALID_SESSION_DATETIME;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_TELEGRAM_DESC = " " + PREFIX_TELEGRAM + "911@"; // '@' not allowed in telegram
@@ -64,6 +70,8 @@ public class CommandTestUtil {
     public static final String INVALID_ATTENDANCE_DESC = " " + PREFIX_ATTENDANCE_TYPE + "notAttendanceType";
     public static final String INVALID_PARTICIPATION_SCORE = " " + PREFIX_CLASS_PARTICIPATION + "-1";
     public static final String INVALID_PARTICIPATION_NONINTEGER = " " + PREFIX_CLASS_PARTICIPATION + "NOTASCORE";
+    public static final String INVALID_SESSION_NAME_DESC = " " + PREFIX_SESSION_NAME + "****"; // '*' not allowed
+
     // refer to {@code AttendanceType} for valid attendance types
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";

--- a/src/test/java/seedu/taskmaster/logic/parser/ChangeSessionCommandParserTest.java
+++ b/src/test/java/seedu/taskmaster/logic/parser/ChangeSessionCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.taskmaster.logic.parser;
 
 import static seedu.taskmaster.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.NEW_SESSION_NAME_DESC;
+import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_SESSION_NAME;
 import static seedu.taskmaster.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.taskmaster.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -22,14 +24,11 @@ public class ChangeSessionCommandParserTest {
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
 
         // no session name specified
-        assertParseFailure(parser, "s/", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, PREFIX_SESSION_NAME.getPrefix(), MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
-        // invalid session name
-        assertParseFailure(parser, "s/****", MESSAGE_INVALID_FORMAT);
-
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "some random string", MESSAGE_INVALID_FORMAT);
 
@@ -39,8 +38,8 @@ public class ChangeSessionCommandParserTest {
 
     @Test
     public void parse_validInput_returnsChangeSessionCommand() {
-        String input = " s/Existing Session";
-        ChangeSessionCommand expectedCommand = new ChangeSessionCommand(new SessionName("Existing Session"));
+        String input = NEW_SESSION_NAME_DESC;
+        ChangeSessionCommand expectedCommand = new ChangeSessionCommand(new SessionName("Tutorial 1"));
         assertParseSuccess(parser, input, expectedCommand);
     }
 }

--- a/src/test/java/seedu/taskmaster/logic/parser/NewSessionCommandParserTest.java
+++ b/src/test/java/seedu/taskmaster/logic/parser/NewSessionCommandParserTest.java
@@ -1,6 +1,13 @@
 package seedu.taskmaster.logic.parser;
 
 import static seedu.taskmaster.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.INVALID_SESSION_NAME_DESC;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.NEW_SESSION_DATETIME_DESC;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.NEW_SESSION_NAME_DESC;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SESSION_DATETIME;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SESSION_NAME;
+import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_SESSION_DATE_TIME;
+import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_SESSION_NAME;
 import static seedu.taskmaster.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.taskmaster.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -22,16 +29,16 @@ public class NewSessionCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no session date time specified
-        assertParseFailure(parser, "s/New Session", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, PREFIX_SESSION_NAME + VALID_SESSION_NAME, MESSAGE_INVALID_FORMAT);
 
         // no session name specified
-        assertParseFailure(parser, "dt/23-10-2020 0900", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, PREFIX_SESSION_DATE_TIME + VALID_SESSION_DATETIME, MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // invalid session name
-        assertParseFailure(parser, "s/****", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, INVALID_SESSION_NAME_DESC, MESSAGE_INVALID_FORMAT);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "some random string", MESSAGE_INVALID_FORMAT);
@@ -42,9 +49,9 @@ public class NewSessionCommandParserTest {
 
     @Test
     public void parse_validInput_returnsNewSessionCommand() {
-        String input = " s/New Session dt/23-10-2020 0900";
+        String input = NEW_SESSION_NAME_DESC + NEW_SESSION_DATETIME_DESC;
         NewSessionCommand expectedCommand = new NewSessionCommand(
-                new SessionName("New Session"),
+                new SessionName(VALID_SESSION_NAME),
                 new SessionDateTime(LocalDateTime.of(2020, 10, 23, 9, 0))
         );
         assertParseSuccess(parser, input, expectedCommand);


### PR DESCRIPTION
# Rename commands to differentiate session and student-related commands

## Summary
Currently, the names of `AddCommand`, `EditCommand`, `DeleteCommand`, `AddSessionCommand` and `DeleteSessionCommand` are not standardized. Users may be confused between an `AddCommand` and `AddSessionCommand`, for example. Let's rename these commands in a standard format. For example, the name of `AddCommand` can be `add-student`, whereas that of `AddSessionCommand` can be `add-session`.
Closes #176 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
