### PR TITLE
Classpart fix

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -201,7 +201,7 @@ score INDEX cp/SCORE
 ```
 - Scores the participation of the student associated with the specified `INDEX` number shown in the displayed student record list.
 - The `INDEX` **must be a positive integer** that exists in said list.
-- The `SCORE` **must be a number** between 0 and 10, inclusive. 
+- The `SCORE` **must be a non-negative number** between 0 and 10, inclusive. 
 Taskmaster supports detailed score up to 2 decimal places.
 For scores with more than 2 decimal places, the score will be rounded to the nearest 2 decimal places.
 
@@ -215,10 +215,10 @@ score 4 cp/4.21
 ### Scoring all students' participation: `score all`
 Scores the participation of all students in the session.
 ```
-score all INDEX cp/SCORE
+score all cp/SCORE
 ```
 - Scores the participation of all students shown in the displayed student record list.
-- The `SCORE` **must be a number** between 0 and 10, inclusive. 
+- The `SCORE` **must be a non-negative number** between 0 and 10, inclusive. 
 Taskmaster supports detailed score up to 2 decimal places.
 For scores with more than 2 decimal places, the score will be rounded to the nearest 2 decimal places.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -194,31 +194,38 @@ mark all a/present
 mark 2 a/absent
 ```
 
-### Scoring a student's participation: `score`
-Scores the participation of the specified student from the student list.
+### Scoring student participation: `score`
+Scores the participation of the specified student in the session.
 ```
 score INDEX cp/SCORE
 ```
 - Scores the participation of the student associated with the specified `INDEX` number shown in the displayed student record list.
 - The `INDEX` **must be a positive integer** that exists in said list.
-- The `SCORE` **must be a positive integer**.
+- The `SCORE` **must be a number** between 0 and 10, inclusive. 
+Taskmaster supports detailed score up to 2 decimal places.
+For scores with more than 2 decimal places, the score will be rounded to the nearest 2 decimal places.
 
 Example Usage:
 ```
 score 1 cp/5
+score 3 cp/6.9
+score 4 cp/4.21
 ```
 
 ### Scoring all students' participation: `score all`
-Scores the participation of all students from the student list.
+Scores the participation of all students in the session.
 ```
 score all INDEX cp/SCORE
 ```
 - Scores the participation of all students shown in the displayed student record list.
-- The `SCORE` **must be a positive integer**.
+- The `SCORE` **must be a number** between 0 and 10, inclusive. 
+Taskmaster supports detailed score up to 2 decimal places.
+For scores with more than 2 decimal places, the score will be rounded to the nearest 2 decimal places.
 
 Example Usage:
 ```
 score all cp/10
+score all cp/2.94
 ```
 
 ### Clearing all entries: `clear`

--- a/src/main/java/seedu/taskmaster/logic/commands/ParticipationAllCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/ParticipationAllCommand.java
@@ -25,7 +25,7 @@ public class ParticipationAllCommand extends ParticipationCommand {
 
     public static final String MESSAGE_MARK_ALL_SUCCESS = "Scored %1$s for all students' participation mark.";
 
-    public ParticipationAllCommand(int score) {
+    public ParticipationAllCommand(double score) {
         super(null, score);
     }
 

--- a/src/main/java/seedu/taskmaster/logic/commands/ParticipationAllCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/ParticipationAllCommand.java
@@ -5,8 +5,10 @@ import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_CLASS_PARTICIPATION
 
 import java.util.List;
 
+import javafx.collections.ObservableList;
 import seedu.taskmaster.logic.commands.exceptions.CommandException;
 import seedu.taskmaster.model.Model;
+import seedu.taskmaster.model.record.StudentRecord;
 import seedu.taskmaster.model.session.exceptions.SessionException;
 import seedu.taskmaster.model.student.Student;
 
@@ -28,7 +30,7 @@ public class ParticipationAllCommand extends ParticipationCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Student> lastShownList = model.getFilteredStudentList();
+        List<StudentRecord> lastShownList = model.getFilteredStudentRecordList();
         try {
             model.scoreAllStudents(lastShownList, score);
         } catch (SessionException sessionException) {

--- a/src/main/java/seedu/taskmaster/logic/commands/ParticipationAllCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/ParticipationAllCommand.java
@@ -30,8 +30,8 @@ public class ParticipationAllCommand extends ParticipationCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<StudentRecord> lastShownList = model.getFilteredStudentRecordList();
         try {
+            List<StudentRecord> lastShownList = model.getFilteredStudentRecordList();
             model.scoreAllStudents(lastShownList, score);
         } catch (SessionException sessionException) {
             throw new CommandException(sessionException.getMessage());

--- a/src/main/java/seedu/taskmaster/logic/commands/ParticipationAllCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/ParticipationAllCommand.java
@@ -5,21 +5,23 @@ import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_CLASS_PARTICIPATION
 
 import java.util.List;
 
-import javafx.collections.ObservableList;
 import seedu.taskmaster.logic.commands.exceptions.CommandException;
 import seedu.taskmaster.model.Model;
 import seedu.taskmaster.model.record.StudentRecord;
 import seedu.taskmaster.model.session.exceptions.SessionException;
-import seedu.taskmaster.model.student.Student;
 
 public class ParticipationAllCommand extends ParticipationCommand {
     public static final String COMMAND_WORD = "score all";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Scores the class participation of all students in the student list.\n"
+            + ": Scores the class participation of the student identified by the "
+            + "index number used in the displayed student list.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_CLASS_PARTICIPATION + "CLASS_PARTICIPATION (default: integer between 0 to 10) \n"
-            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_CLASS_PARTICIPATION + "7";
+            + PREFIX_CLASS_PARTICIPATION
+            + "CLASS_PARTICIPATION (between 0 to 10 inclusive, allows for 2 decimal points) \n"
+            + "You may substitute INDEX for the word 'all' to mark all students in the session. \n"
+            + "Example 1: " + COMMAND_WORD + " 1 " + PREFIX_CLASS_PARTICIPATION + "7\n"
+            + "Example 2: " + COMMAND_WORD + " all " + PREFIX_CLASS_PARTICIPATION + "6\n";
 
     public static final String MESSAGE_MARK_ALL_SUCCESS = "Scored %1$s for all students' participation mark.";
 

--- a/src/main/java/seedu/taskmaster/logic/commands/ParticipationCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/ParticipationCommand.java
@@ -29,14 +29,14 @@ public class ParticipationCommand extends Command {
             + "Example 2: " + COMMAND_WORD + " all " + PREFIX_CLASS_PARTICIPATION + "6\n";
 
     public static final String MESSAGE_SCORE_STUDENT_SUCCESS = "%1$s scored %2$s for class participation";
-    protected final int score;
+    protected final double score;
     private final Index targetIndex;
 
     /**
      * @param targetIndex of the student in the filtered student list to mark
      * @param newScore as the new score of the student
      */
-    public ParticipationCommand(Index targetIndex, int newScore) {
+    public ParticipationCommand(Index targetIndex, double newScore) {
         this.targetIndex = targetIndex;
         this.score = newScore;
     }
@@ -44,7 +44,7 @@ public class ParticipationCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        StudentRecord studentToScore = null;
+        StudentRecord studentToScore;
         try {
             int index = targetIndex.getZeroBased();
             List<StudentRecord> lastShownList = model.getFilteredStudentRecordList();
@@ -58,7 +58,7 @@ public class ParticipationCommand extends Command {
         } catch (SessionException sessionException) {
             throw new CommandException(sessionException.getMessage());
         }
-        return new CommandResult(String.format(MESSAGE_SCORE_STUDENT_SUCCESS, studentToScore, score));
+        return new CommandResult(String.format(MESSAGE_SCORE_STUDENT_SUCCESS, studentToScore.getName(), score));
     }
 
     @Override

--- a/src/main/java/seedu/taskmaster/logic/commands/ParticipationCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/ParticipationCommand.java
@@ -9,8 +9,8 @@ import seedu.taskmaster.commons.core.Messages;
 import seedu.taskmaster.commons.core.index.Index;
 import seedu.taskmaster.logic.commands.exceptions.CommandException;
 import seedu.taskmaster.model.Model;
+import seedu.taskmaster.model.record.StudentRecord;
 import seedu.taskmaster.model.session.exceptions.SessionException;
-import seedu.taskmaster.model.student.Student;
 
 /**
  * Marks the participation of a student identified using its displayed index from the student list.
@@ -41,15 +41,16 @@ public class ParticipationCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        int index = targetIndex.getZeroBased();
-        List<Student> lastShownList = model.getFilteredStudentList();
-
-        if (index >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
-        }
-
-        Student studentToScore = lastShownList.get(index);
+        StudentRecord studentToScore = null;
         try {
+            int index = targetIndex.getZeroBased();
+            List<StudentRecord> lastShownList = model.getFilteredStudentRecordList();
+
+            if (index >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+            }
+
+            studentToScore = lastShownList.get(index);
             model.scoreStudent(studentToScore, score);
         } catch (SessionException sessionException) {
             throw new CommandException(sessionException.getMessage());

--- a/src/main/java/seedu/taskmaster/logic/commands/ParticipationCommand.java
+++ b/src/main/java/seedu/taskmaster/logic/commands/ParticipationCommand.java
@@ -22,8 +22,11 @@ public class ParticipationCommand extends Command {
             + ": Scores the class participation of the student identified by the "
             + "index number used in the displayed student list.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_CLASS_PARTICIPATION + "CLASS_PARTICIPATION (default: integer between 0 to 10) \n"
-            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_CLASS_PARTICIPATION + "7";
+            + PREFIX_CLASS_PARTICIPATION
+            + "CLASS_PARTICIPATION (between 0 to 10 inclusive, allows for 2 decimal points) \n"
+            + "You may substitute INDEX for the word 'all' to mark all students in the session. \n"
+            + "Example 1: " + COMMAND_WORD + " 1 " + PREFIX_CLASS_PARTICIPATION + "7\n"
+            + "Example 2: " + COMMAND_WORD + " all " + PREFIX_CLASS_PARTICIPATION + "6\n";
 
     public static final String MESSAGE_SCORE_STUDENT_SUCCESS = "%1$s scored %2$s for class participation";
     protected final int score;

--- a/src/main/java/seedu/taskmaster/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/taskmaster/logic/parser/ParserUtil.java
@@ -192,21 +192,23 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String score} into a score.
+     * Parses a {@code String score} into a double array.
+     * First entry of the array would be a isNegative flag, second entry is the parsed score.
      * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code score} is invalid.
      */
-    public static double parseScore(String score) throws ParseException {
+    public static double[] parseScore(String score) throws ParseException {
         requireNonNull(score);
         String trimmedScore = score.trim();
+
         double parsedScore = 0;
         try {
-            double in = Double.valueOf(trimmedScore);
-            parsedScore = Math.round(in * 100.0) / 100.0;
+            parsedScore = Double.valueOf(trimmedScore);
+            double negativeFlag = trimmedScore.charAt(0) == '-' ? 1 : 0;
+            return new double[]{negativeFlag, parsedScore};
         } catch (NumberFormatException e) {
             throw new ParseException(ClassParticipation.MESSAGE_CONSTRAINTS);
         }
-        return parsedScore;
     }
 }

--- a/src/main/java/seedu/taskmaster/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/taskmaster/logic/parser/ParserUtil.java
@@ -197,12 +197,13 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code score} is invalid.
      */
-    public static int parseScore(String score) throws ParseException {
+    public static double parseScore(String score) throws ParseException {
         requireNonNull(score);
         String trimmedScore = score.trim();
-        int parsedScore = 0;
+        double parsedScore = 0;
         try {
-            parsedScore = Integer.valueOf(score);
+            double in = Double.valueOf(trimmedScore);
+            parsedScore = Math.round(in * 100.0) / 100.0;
         } catch (NumberFormatException e) {
             throw new ParseException(ClassParticipation.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/taskmaster/logic/parser/ParticipationCommandParser.java
+++ b/src/main/java/seedu/taskmaster/logic/parser/ParticipationCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_CLASS_PARTICIPATION
 import java.util.NoSuchElementException;
 
 import seedu.taskmaster.commons.core.index.Index;
+import seedu.taskmaster.commons.exceptions.IllegalValueException;
 import seedu.taskmaster.logic.commands.ParticipationAllCommand;
 import seedu.taskmaster.logic.commands.ParticipationCommand;
 import seedu.taskmaster.logic.parser.exceptions.ParseException;
@@ -30,9 +31,11 @@ public class ParticipationCommandParser implements Parser<ParticipationCommand> 
             String preamble = argMultimap.getPreamble();
 
             if (score < 0) {
-                throw new ParseException("Negative score.");
+                throw new IllegalValueException(
+                        "Invalid input: Negative score. Score needs to be between 0 to 10 inclusive.");
             } else if (score > 10) {
-                throw new ParseException("Score is greater than 10.");
+                throw new IllegalValueException(
+                        "Invalid input: Score is greater than 10. Score needs to be between 0 to 10 inclusive.");
             }
 
             if (preamble.equals("all")) {
@@ -44,6 +47,10 @@ public class ParticipationCommandParser implements Parser<ParticipationCommand> 
         } catch (ParseException | NoSuchElementException e) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ParticipationCommand.MESSAGE_USAGE), e);
+        } catch (IllegalValueException e) {
+            throw new ParseException(
+                    e.getMessage()
+            );
         }
     }
 }

--- a/src/main/java/seedu/taskmaster/logic/parser/ParticipationCommandParser.java
+++ b/src/main/java/seedu/taskmaster/logic/parser/ParticipationCommandParser.java
@@ -23,7 +23,7 @@ public class ParticipationCommandParser implements Parser<ParticipationCommand> 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CLASS_PARTICIPATION);
 
         Index index;
-        int score;
+        double score;
 
         try {
             score = ParserUtil.parseScore(argMultimap.getValue(PREFIX_CLASS_PARTICIPATION).get());

--- a/src/main/java/seedu/taskmaster/logic/parser/ParticipationCommandParser.java
+++ b/src/main/java/seedu/taskmaster/logic/parser/ParticipationCommandParser.java
@@ -25,15 +25,24 @@ public class ParticipationCommandParser implements Parser<ParticipationCommand> 
 
         Index index;
         double score;
+        double rawScore;
+        double[] raw; // [negative 1/0 flag, rawScore]
+        boolean isNegative;
 
         try {
-            score = ParserUtil.parseScore(argMultimap.getValue(PREFIX_CLASS_PARTICIPATION).get());
+            raw = ParserUtil.parseScore(argMultimap.getValue(PREFIX_CLASS_PARTICIPATION).get());
+            rawScore = raw[1];
+            isNegative = raw[0] == 1;
+
+            score = Math.round(rawScore * 100.0) / 100.0;
             String preamble = argMultimap.getPreamble();
 
-            if (score < 0) {
+            if (isNegative && rawScore == 0) {
+                throw new IllegalValueException("Invalid input: Do not put - before zero.");
+            } else if (rawScore < 0) {
                 throw new IllegalValueException(
                         "Invalid input: Negative score. Score needs to be between 0 to 10 inclusive.");
-            } else if (score > 10) {
+            } else if (rawScore > 10) {
                 throw new IllegalValueException(
                         "Invalid input: Score is greater than 10. Score needs to be between 0 to 10 inclusive.");
             }

--- a/src/main/java/seedu/taskmaster/logic/parser/ParticipationCommandParser.java
+++ b/src/main/java/seedu/taskmaster/logic/parser/ParticipationCommandParser.java
@@ -30,7 +30,9 @@ public class ParticipationCommandParser implements Parser<ParticipationCommand> 
             String preamble = argMultimap.getPreamble();
 
             if (score < 0) {
-                throw new ParseException("Negative score");
+                throw new ParseException("Negative score.");
+            } else if (score > 10) {
+                throw new ParseException("Score is greater than 10.");
             }
 
             if (preamble.equals("all")) {

--- a/src/main/java/seedu/taskmaster/model/Model.java
+++ b/src/main/java/seedu/taskmaster/model/Model.java
@@ -151,7 +151,7 @@ public interface Model {
      * Marks the attendance of the given student {@code target} with the given {@code attendanceType}.
      * The student must exist in the student list.
      */
-    void scoreStudent(Student target, int score);
+    void scoreStudent(StudentRecord target, int score);
 
     void scoreStudentWithNusnetId(NusnetId nusnetId, int score);
 

--- a/src/main/java/seedu/taskmaster/model/Model.java
+++ b/src/main/java/seedu/taskmaster/model/Model.java
@@ -158,7 +158,7 @@ public interface Model {
     /**
      * Marks the attendances of all {@code students} with the given {@code attendanceType}
      */
-    void scoreAllStudents(List<Student> students, int score);
+    void scoreAllStudents(List<StudentRecord> students, int score);
 
     /**
      * Updates the corresponding attendance statuses with the Attendances in the given list.

--- a/src/main/java/seedu/taskmaster/model/Model.java
+++ b/src/main/java/seedu/taskmaster/model/Model.java
@@ -151,14 +151,14 @@ public interface Model {
      * Marks the attendance of the given student {@code target} with the given {@code attendanceType}.
      * The student must exist in the student list.
      */
-    void scoreStudent(StudentRecord target, int score);
+    void scoreStudent(StudentRecord target, double score);
 
-    void scoreStudentWithNusnetId(NusnetId nusnetId, int score);
+    void scoreStudentWithNusnetId(NusnetId nusnetId, double score);
 
     /**
      * Marks the attendances of all {@code students} with the given {@code attendanceType}
      */
-    void scoreAllStudents(List<StudentRecord> students, int score);
+    void scoreAllStudents(List<StudentRecord> students, double score);
 
     /**
      * Updates the corresponding attendance statuses with the Attendances in the given list.

--- a/src/main/java/seedu/taskmaster/model/ModelManager.java
+++ b/src/main/java/seedu/taskmaster/model/ModelManager.java
@@ -186,10 +186,10 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void scoreAllStudents(List<Student> students, int score) {
+    public void scoreAllStudents(List<StudentRecord> students, int score) {
         List<NusnetId> nusnetIds = students
                 .stream()
-                .map(Student::getNusnetId)
+                .map(StudentRecord::getNusnetId)
                 .collect(Collectors.toList());
 
         taskmaster.scoreAllStudents(nusnetIds, score);

--- a/src/main/java/seedu/taskmaster/model/ModelManager.java
+++ b/src/main/java/seedu/taskmaster/model/ModelManager.java
@@ -174,7 +174,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void scoreStudent(Student target, int score) {
+    public void scoreStudent(StudentRecord target, int score) {
         requireAllNonNull(target, score);
         taskmaster.scoreStudent(target, score);
     }

--- a/src/main/java/seedu/taskmaster/model/ModelManager.java
+++ b/src/main/java/seedu/taskmaster/model/ModelManager.java
@@ -174,19 +174,19 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void scoreStudent(StudentRecord target, int score) {
+    public void scoreStudent(StudentRecord target, double score) {
         requireAllNonNull(target, score);
         taskmaster.scoreStudent(target, score);
     }
 
     @Override
-    public void scoreStudentWithNusnetId(NusnetId nusnetId, int score) {
+    public void scoreStudentWithNusnetId(NusnetId nusnetId, double score) {
         requireAllNonNull(nusnetId, score);
         taskmaster.scoreStudentWithNusnetId(nusnetId, score);
     }
 
     @Override
-    public void scoreAllStudents(List<StudentRecord> students, int score) {
+    public void scoreAllStudents(List<StudentRecord> students, double score) {
         List<NusnetId> nusnetIds = students
                 .stream()
                 .map(StudentRecord::getNusnetId)

--- a/src/main/java/seedu/taskmaster/model/Taskmaster.java
+++ b/src/main/java/seedu/taskmaster/model/Taskmaster.java
@@ -240,7 +240,7 @@ public class Taskmaster implements ReadOnlyTaskmaster {
      * @throws NoSessionException If the session list is empty.
      * @throws NoSessionSelectedException If no session has been selected.
      */
-    public void scoreStudent(Student target, int score)
+    public void scoreStudent(StudentRecord target, int score)
             throws NoSessionException, NoSessionSelectedException {
         assert target != null;
 

--- a/src/main/java/seedu/taskmaster/model/Taskmaster.java
+++ b/src/main/java/seedu/taskmaster/model/Taskmaster.java
@@ -240,7 +240,7 @@ public class Taskmaster implements ReadOnlyTaskmaster {
      * @throws NoSessionException If the session list is empty.
      * @throws NoSessionSelectedException If no session has been selected.
      */
-    public void scoreStudent(StudentRecord target, int score)
+    public void scoreStudent(StudentRecord target, double score)
             throws NoSessionException, NoSessionSelectedException {
         assert target != null;
 
@@ -260,7 +260,7 @@ public class Taskmaster implements ReadOnlyTaskmaster {
      * @throws NoSessionException If the session list is empty.
      * @throws NoSessionSelectedException If no session has been selected.
      */
-    public void scoreStudentWithNusnetId(NusnetId nusnetId, int score)
+    public void scoreStudentWithNusnetId(NusnetId nusnetId, double score)
             throws NoSessionException, NoSessionSelectedException {
         assert nusnetId != null;
 
@@ -280,7 +280,7 @@ public class Taskmaster implements ReadOnlyTaskmaster {
      * @throws NoSessionException If the session list is empty.
      * @throws NoSessionSelectedException If no session has been selected.
      */
-    public void scoreAllStudents(List<NusnetId> nusnetIds, int score)
+    public void scoreAllStudents(List<NusnetId> nusnetIds, double score)
             throws NoSessionException, NoSessionSelectedException {
         assert nusnetIds != null;
 

--- a/src/main/java/seedu/taskmaster/model/record/ClassParticipation.java
+++ b/src/main/java/seedu/taskmaster/model/record/ClassParticipation.java
@@ -4,7 +4,7 @@ package seedu.taskmaster.model.record;
 public class ClassParticipation {
     public static final String MESSAGE_CONSTRAINTS = "The score of a student needs to be a positive integer.";
 
-    private int score = 0;
+    private double score = 0;
 
     /**
      * Constructor method for Class Participation
@@ -20,7 +20,7 @@ public class ClassParticipation {
      * Uses the default maximum score, which is 10
      * The score is set to the wanted score
      */
-    public ClassParticipation(int score) {
+    public ClassParticipation(double score) {
         assert score >= 0;
         this.score = score;
     }
@@ -28,13 +28,14 @@ public class ClassParticipation {
     /**
      * Returns the class participation score as an integer.
      */
-    public int getRawScore() {
+    public double getRawScore() {
         return this.score;
     }
 
     @Override
     public String toString() {
-        return "Class Participation Score: " + score;
+        String formattedScore = String.format("%.2f", score);
+        return "Class Participation Score: " + formattedScore;
     }
 
     public String description() {

--- a/src/main/java/seedu/taskmaster/model/record/StudentRecordList.java
+++ b/src/main/java/seedu/taskmaster/model/record/StudentRecordList.java
@@ -21,12 +21,12 @@ public interface StudentRecordList extends Iterable<StudentRecord> {
     /**
      * Updates participation score of a student represented by their {@code nusnetId} to {@code score}.
      */
-    void scoreStudentParticipation(NusnetId nusnetId, int score);
+    void scoreStudentParticipation(NusnetId nusnetId, double score);
 
     /**
      * Updates participation score of all students in the list of {@code nusnetIds} with {@code attendanceType}.
      */
-    void scoreAllParticipation(List<NusnetId> nusnetIds, int score);
+    void scoreAllParticipation(List<NusnetId> nusnetIds, double score);
 
 
     void setStudentRecords(StudentRecordListManager replacement);

--- a/src/main/java/seedu/taskmaster/model/record/StudentRecordListManager.java
+++ b/src/main/java/seedu/taskmaster/model/record/StudentRecordListManager.java
@@ -81,7 +81,7 @@ public class StudentRecordListManager implements StudentRecordList {
      * Updates participation score of a student represented by their {@code nusnetId} to {@code score}.
      */
     @Override
-    public void scoreStudentParticipation(NusnetId nusnetId, int score) {
+    public void scoreStudentParticipation(NusnetId nusnetId, double score) {
         requireAllNonNull(nusnetId);
 
         boolean isFound = false;
@@ -108,7 +108,7 @@ public class StudentRecordListManager implements StudentRecordList {
      * Updates participation score of all students in the list of {@code nusnetIds} with {@code attendanceType}.
      */
     @Override
-    public void scoreAllParticipation(List<NusnetId> nusnetIds, int score) {
+    public void scoreAllParticipation(List<NusnetId> nusnetIds, double score) {
         for (NusnetId nusnetId : nusnetIds) {
             scoreStudentParticipation(nusnetId, score);
         }

--- a/src/main/java/seedu/taskmaster/model/session/Session.java
+++ b/src/main/java/seedu/taskmaster/model/session/Session.java
@@ -80,12 +80,12 @@ public class Session {
      * Marks the attendance of a student with the given {@code nusnetId} in the
      * student record list with {@code attendanceType}.
      */
-    public void scoreStudentParticipation(NusnetId nusnetId, int score) {
+    public void scoreStudentParticipation(NusnetId nusnetId, double score) {
         assert nusnetId != null;
         studentRecords.scoreStudentParticipation(nusnetId, score);
     }
 
-    public void scoreAllParticipation(List<NusnetId> nusnetIds, int score) {
+    public void scoreAllParticipation(List<NusnetId> nusnetIds, double score) {
         studentRecords.scoreAllParticipation(nusnetIds, score);
     }
 

--- a/src/test/java/seedu/taskmaster/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/AddCommandTest.java
@@ -227,7 +227,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void scoreAllStudents(List<Student> students, int score) {
+        public void scoreAllStudents(List<StudentRecord> students, int score) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/taskmaster/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/AddCommandTest.java
@@ -217,7 +217,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void scoreStudent(Student target, int score) {
+        public void scoreStudent(StudentRecord target, int score) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/taskmaster/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/AddCommandTest.java
@@ -217,17 +217,17 @@ public class AddCommandTest {
         }
 
         @Override
-        public void scoreStudent(StudentRecord target, int score) {
+        public void scoreStudent(StudentRecord target, double score) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void scoreStudentWithNusnetId(NusnetId nusnetId, int score) {
+        public void scoreStudentWithNusnetId(NusnetId nusnetId, double score) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void scoreAllStudents(List<StudentRecord> students, int score) {
+        public void scoreAllStudents(List<StudentRecord> students, double score) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/taskmaster/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/CommandTestUtil.java
@@ -63,6 +63,8 @@ public class CommandTestUtil {
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
     public static final String INVALID_ATTENDANCE_DESC = " " + PREFIX_ATTENDANCE_TYPE + "notAttendanceType";
     public static final String INVALID_PARTICIPATION_SCORE = " " + PREFIX_CLASS_PARTICIPATION + "-1";
+    public static final String INVALID_PARTICIPATION_TOOSMALL = " " + PREFIX_CLASS_PARTICIPATION + "-1";
+    public static final String INVALID_PARTICIPATION_TOOBIG = " " + PREFIX_CLASS_PARTICIPATION + "10.1";
     public static final String INVALID_PARTICIPATION_NONINTEGER = " " + PREFIX_CLASS_PARTICIPATION + "NOTASCORE";
     // refer to {@code AttendanceType} for valid attendance types
 

--- a/src/test/java/seedu/taskmaster/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/CommandTestUtil.java
@@ -40,8 +40,8 @@ public class CommandTestUtil {
     public static final String VALID_TAG_FRIEND = "friend";
     public static final String PRESENT_ATTENDANCE = "present";
     public static final String ABSENT_ATTENDANCE = "absent";
-    public static final String VALID_SCORE_STRING = "0";
-    public static final int VALID_SCORE_INT = 0;
+    public static final String VALID_SCORE_STRING = "0.00";
+    public static final double VALID_SCORE_DOUBLE = 0;
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/taskmaster/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/CommandTestUtil.java
@@ -64,6 +64,7 @@ public class CommandTestUtil {
     public static final String INVALID_ATTENDANCE_DESC = " " + PREFIX_ATTENDANCE_TYPE + "notAttendanceType";
     public static final String INVALID_PARTICIPATION_SCORE = " " + PREFIX_CLASS_PARTICIPATION + "-1";
     public static final String INVALID_PARTICIPATION_TOOSMALL = " " + PREFIX_CLASS_PARTICIPATION + "-1";
+    public static final String INVALID_PARTICIPATION_NEGATIVEZERO = " " + PREFIX_CLASS_PARTICIPATION + "-0";
     public static final String INVALID_PARTICIPATION_TOOBIG = " " + PREFIX_CLASS_PARTICIPATION + "10.1";
     public static final String INVALID_PARTICIPATION_NONINTEGER = " " + PREFIX_CLASS_PARTICIPATION + "NOTASCORE";
     // refer to {@code AttendanceType} for valid attendance types

--- a/src/test/java/seedu/taskmaster/logic/commands/ParticipationAllCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/ParticipationAllCommandTest.java
@@ -2,7 +2,8 @@ package seedu.taskmaster.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_INT;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_DOUBLE;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_STRING;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.taskmaster.testutil.TypicalStudents.getTypicalTaskmaster;
@@ -27,34 +28,35 @@ class ParticipationAllCommandTest {
     public void execute_participationAllStudents_success() {
         model.changeSession(new SessionName("Typical session"));
         List<StudentRecord> students = model.getFilteredStudentRecordList();
-        ParticipationAllCommand participationAllCommand = new ParticipationAllCommand(VALID_SCORE_INT);
+        ParticipationAllCommand participationAllCommand = new ParticipationAllCommand(VALID_SCORE_DOUBLE);
         Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
         expectedModel.changeSession(new SessionName("Typical session"));
-        expectedModel.scoreAllStudents(students, VALID_SCORE_INT);
-        String expectedMessage = String.format(ParticipationAllCommand.MESSAGE_MARK_ALL_SUCCESS, VALID_SCORE_INT);
+        expectedModel.scoreAllStudents(students, VALID_SCORE_DOUBLE);
+        String expectedMessage = String.format(
+                ParticipationAllCommand.MESSAGE_MARK_ALL_SUCCESS, Double.parseDouble(VALID_SCORE_STRING));
         assertCommandSuccess(participationAllCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_emptySessionList_exceptionThrown() {
         model.setSessions(new ArrayList<>());
-        ParticipationAllCommand participationAllCommand = new ParticipationAllCommand(VALID_SCORE_INT);
+        ParticipationAllCommand participationAllCommand = new ParticipationAllCommand(VALID_SCORE_DOUBLE);
         String expectedMessage = "There are no sessions yet!";
         assertCommandFailure(participationAllCommand, model, expectedMessage);
     }
 
     @Test
     public void execute_nullCurrentSession_exceptionThrown() {
-        ParticipationAllCommand participationAllCommand = new ParticipationAllCommand(VALID_SCORE_INT);
+        ParticipationAllCommand participationAllCommand = new ParticipationAllCommand(VALID_SCORE_DOUBLE);
         String expectedMessage = "Please select a session first!";
         assertCommandFailure(participationAllCommand, model, expectedMessage);
     }
 
     @Test
     void testEquals() {
-        ParticipationAllCommand partCommand1 = new ParticipationAllCommand(VALID_SCORE_INT);
-        ParticipationAllCommand partCommand2 = new ParticipationAllCommand(VALID_SCORE_INT);
-        ParticipationAllCommand partCommand3 = new ParticipationAllCommand(VALID_SCORE_INT + 1);
+        ParticipationAllCommand partCommand1 = new ParticipationAllCommand(VALID_SCORE_DOUBLE);
+        ParticipationAllCommand partCommand2 = new ParticipationAllCommand(VALID_SCORE_DOUBLE);
+        ParticipationAllCommand partCommand3 = new ParticipationAllCommand(VALID_SCORE_DOUBLE + 1);
         assertTrue(partCommand1.equals(partCommand1));
         assertTrue(partCommand1.equals(partCommand2));
         assertFalse(partCommand1.equals(partCommand3));

--- a/src/test/java/seedu/taskmaster/logic/commands/ParticipationAllCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/ParticipationAllCommandTest.java
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.Test;
 import seedu.taskmaster.model.Model;
 import seedu.taskmaster.model.ModelManager;
 import seedu.taskmaster.model.UserPrefs;
+import seedu.taskmaster.model.record.StudentRecord;
 import seedu.taskmaster.model.session.SessionName;
-import seedu.taskmaster.model.student.Student;
 
 
 
@@ -26,7 +26,7 @@ class ParticipationAllCommandTest {
     @Test
     public void execute_participationAllStudents_success() {
         model.changeSession(new SessionName("Typical session"));
-        List<Student> students = model.getFilteredStudentList();
+        List<StudentRecord> students = model.getFilteredStudentRecordList();
         ParticipationAllCommand participationAllCommand = new ParticipationAllCommand(VALID_SCORE_INT);
         Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
         expectedModel.changeSession(new SessionName("Typical session"));

--- a/src/test/java/seedu/taskmaster/logic/commands/ParticipationCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/ParticipationCommandTest.java
@@ -2,7 +2,8 @@ package seedu.taskmaster.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_INT;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_DOUBLE;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_STRING;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.taskmaster.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
@@ -28,13 +29,17 @@ class ParticipationCommandTest {
     @Test
     public void execute_participationWithValidIndex_success() {
         model.changeSession(new SessionName("Typical session"));
+        StudentRecord firstStudentRecord = model
+                .getFilteredStudentRecordList()
+                .get(INDEX_FIRST_STUDENT.getZeroBased());
+
         Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
         expectedModel.changeSession(new SessionName("Typical session"));
-        StudentRecord firstStudent = model.getFilteredStudentRecordList().get(INDEX_FIRST_STUDENT.getZeroBased());
-        ParticipationCommand participationCommand = new ParticipationCommand(INDEX_FIRST_STUDENT, VALID_SCORE_INT);
-        expectedModel.scoreStudent(firstStudent, VALID_SCORE_INT);
+        ParticipationCommand participationCommand = new ParticipationCommand(INDEX_FIRST_STUDENT, VALID_SCORE_DOUBLE);
+        expectedModel.scoreStudent(firstStudentRecord, VALID_SCORE_DOUBLE);
+
         String expectedMessage = String.format(ParticipationCommand.MESSAGE_SCORE_STUDENT_SUCCESS,
-                firstStudent, VALID_SCORE_INT);
+                firstStudentRecord.getName(), Double.parseDouble(VALID_SCORE_STRING));
         assertCommandSuccess(participationCommand, model, expectedMessage, expectedModel);
     }
 
@@ -43,31 +48,31 @@ class ParticipationCommandTest {
         model.changeSession(new SessionName("Typical session"));
         int numOfStudents = model.getFilteredStudentList().size();
         Index indexTooBig = Index.fromZeroBased(numOfStudents);
-        ParticipationCommand participationCommand = new ParticipationCommand(indexTooBig, VALID_SCORE_INT);
+        ParticipationCommand participationCommand = new ParticipationCommand(indexTooBig, VALID_SCORE_DOUBLE);
         assertCommandFailure(participationCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
 
     @Test
     public void execute_emptySessionList_exceptionThrown() {
         model.setSessions(new ArrayList<>());
-        ParticipationCommand participationCommand = new ParticipationCommand(INDEX_FIRST_STUDENT, VALID_SCORE_INT);
+        ParticipationCommand participationCommand = new ParticipationCommand(INDEX_FIRST_STUDENT, VALID_SCORE_DOUBLE);
         String expectedMessage = "There are no sessions yet!";
         assertCommandFailure(participationCommand, model, expectedMessage);
     }
 
     @Test
     public void execute_nullCurrentSession_exceptionThrown() {
-        ParticipationCommand participationCommand = new ParticipationCommand(INDEX_FIRST_STUDENT, VALID_SCORE_INT);
+        ParticipationCommand participationCommand = new ParticipationCommand(INDEX_FIRST_STUDENT, VALID_SCORE_DOUBLE);
         String expectedMessage = "Please select a session first!";
         assertCommandFailure(participationCommand, model, expectedMessage);
     }
 
     @Test
     void testEquals() {
-        ParticipationCommand partCommand1 = new ParticipationCommand(INDEX_FIRST_STUDENT, VALID_SCORE_INT);
-        ParticipationCommand partCommand2 = new ParticipationCommand(INDEX_FIRST_STUDENT, VALID_SCORE_INT);
-        ParticipationCommand partCommand3 = new ParticipationCommand(INDEX_SECOND_STUDENT, VALID_SCORE_INT);
-        ParticipationCommand partCommand4 = new ParticipationCommand(INDEX_SECOND_STUDENT, VALID_SCORE_INT + 1);
+        ParticipationCommand partCommand1 = new ParticipationCommand(INDEX_FIRST_STUDENT, VALID_SCORE_DOUBLE);
+        ParticipationCommand partCommand2 = new ParticipationCommand(INDEX_FIRST_STUDENT, VALID_SCORE_DOUBLE);
+        ParticipationCommand partCommand3 = new ParticipationCommand(INDEX_SECOND_STUDENT, VALID_SCORE_DOUBLE);
+        ParticipationCommand partCommand4 = new ParticipationCommand(INDEX_SECOND_STUDENT, VALID_SCORE_DOUBLE + 1);
         assertTrue(partCommand1.equals(partCommand1));
         assertTrue(partCommand1.equals(partCommand2));
         assertFalse(partCommand1.equals(partCommand3));

--- a/src/test/java/seedu/taskmaster/logic/commands/ParticipationCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/ParticipationCommandTest.java
@@ -18,9 +18,8 @@ import seedu.taskmaster.commons.core.index.Index;
 import seedu.taskmaster.model.Model;
 import seedu.taskmaster.model.ModelManager;
 import seedu.taskmaster.model.UserPrefs;
+import seedu.taskmaster.model.record.StudentRecord;
 import seedu.taskmaster.model.session.SessionName;
-import seedu.taskmaster.model.student.Student;
-
 
 class ParticipationCommandTest {
 
@@ -31,7 +30,7 @@ class ParticipationCommandTest {
         model.changeSession(new SessionName("Typical session"));
         Model expectedModel = new ModelManager(getTypicalTaskmaster(), new UserPrefs());
         expectedModel.changeSession(new SessionName("Typical session"));
-        Student firstStudent = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        StudentRecord firstStudent = model.getFilteredStudentRecordList().get(INDEX_FIRST_STUDENT.getZeroBased());
         ParticipationCommand participationCommand = new ParticipationCommand(INDEX_FIRST_STUDENT, VALID_SCORE_INT);
         expectedModel.scoreStudent(firstStudent, VALID_SCORE_INT);
         String expectedMessage = String.format(ParticipationCommand.MESSAGE_SCORE_STUDENT_SUCCESS,

--- a/src/test/java/seedu/taskmaster/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/taskmaster/logic/parser/ParserUtilTest.java
@@ -206,7 +206,7 @@ public class ParserUtilTest {
 
     @Test
     void parseScore_validInput() throws Exception {
-        int res = ParserUtil.parseScore(VALID_SCORE_STRING);
+        double res = ParserUtil.parseScore(VALID_SCORE_STRING);
         assertEquals(VALID_SCORE_INT, res);
     }
 }

--- a/src/test/java/seedu/taskmaster/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/taskmaster/logic/parser/ParserUtilTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.INVALID_PARTICIPATION_NONINTEGER;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.INVALID_PARTICIPATION_SCORE;
-import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_INT;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_DOUBLE;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_STRING;
 import static seedu.taskmaster.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.taskmaster.testutil.Assert.assertThrows;
@@ -207,6 +207,6 @@ public class ParserUtilTest {
     @Test
     void parseScore_validInput() throws Exception {
         double res = ParserUtil.parseScore(VALID_SCORE_STRING);
-        assertEquals(VALID_SCORE_INT, res);
+        assertEquals(VALID_SCORE_DOUBLE, res);
     }
 }

--- a/src/test/java/seedu/taskmaster/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/taskmaster/logic/parser/ParserUtilTest.java
@@ -206,7 +206,7 @@ public class ParserUtilTest {
 
     @Test
     void parseScore_validInput() throws Exception {
-        double res = ParserUtil.parseScore(VALID_SCORE_STRING);
+        double res = ParserUtil.parseScore(VALID_SCORE_STRING)[0];
         assertEquals(VALID_SCORE_DOUBLE, res);
     }
 }

--- a/src/test/java/seedu/taskmaster/logic/parser/ParticipationCommandParserTest.java
+++ b/src/test/java/seedu/taskmaster/logic/parser/ParticipationCommandParserTest.java
@@ -2,7 +2,8 @@ package seedu.taskmaster.logic.parser;
 
 import static seedu.taskmaster.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.INVALID_PARTICIPATION_NONINTEGER;
-import static seedu.taskmaster.logic.commands.CommandTestUtil.INVALID_PARTICIPATION_SCORE;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.INVALID_PARTICIPATION_TOOBIG;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.INVALID_PARTICIPATION_TOOSMALL;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.PREAMBLE_ALL;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_NAME_AMY;
@@ -22,6 +23,10 @@ import seedu.taskmaster.logic.commands.ParticipationCommand;
 class ParticipationCommandParserTest {
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, ParticipationCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INVALID_INPUT_TOO_SMALL =
+            "Invalid input: Negative score. Score needs to be between 0 to 10 inclusive.";
+    private static final String MESSAGE_INVALID_INPUT_TOO_BIG =
+            "Invalid input: Score is greater than 10. Score needs to be between 0 to 10 inclusive.";
 
     private ParticipationCommandParser parser = new ParticipationCommandParser();
 
@@ -55,7 +60,8 @@ class ParticipationCommandParserTest {
     @Test
     public void parse_invalidAttendanceType_failure() {
         assertParseFailure(parser, "1" + INVALID_PARTICIPATION_NONINTEGER, MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, "1" + INVALID_PARTICIPATION_SCORE, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1" + INVALID_PARTICIPATION_TOOSMALL, MESSAGE_INVALID_INPUT_TOO_SMALL);
+        assertParseFailure(parser, "1" + INVALID_PARTICIPATION_TOOBIG, MESSAGE_INVALID_INPUT_TOO_BIG);
     }
 
     @Test

--- a/src/test/java/seedu/taskmaster/logic/parser/ParticipationCommandParserTest.java
+++ b/src/test/java/seedu/taskmaster/logic/parser/ParticipationCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.taskmaster.logic.parser;
 
 import static seedu.taskmaster.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.INVALID_PARTICIPATION_NEGATIVEZERO;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.INVALID_PARTICIPATION_NONINTEGER;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.INVALID_PARTICIPATION_TOOBIG;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.INVALID_PARTICIPATION_TOOSMALL;
@@ -27,6 +28,8 @@ class ParticipationCommandParserTest {
             "Invalid input: Negative score. Score needs to be between 0 to 10 inclusive.";
     private static final String MESSAGE_INVALID_INPUT_TOO_BIG =
             "Invalid input: Score is greater than 10. Score needs to be between 0 to 10 inclusive.";
+    private static final String MESSAGE_INVALID_NEGATIVE_ZERO =
+            "Invalid input: Do not put - before zero.";
 
     private ParticipationCommandParser parser = new ParticipationCommandParser();
 
@@ -62,6 +65,7 @@ class ParticipationCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_PARTICIPATION_NONINTEGER, MESSAGE_INVALID_FORMAT);
         assertParseFailure(parser, "1" + INVALID_PARTICIPATION_TOOSMALL, MESSAGE_INVALID_INPUT_TOO_SMALL);
         assertParseFailure(parser, "1" + INVALID_PARTICIPATION_TOOBIG, MESSAGE_INVALID_INPUT_TOO_BIG);
+        assertParseFailure(parser, "1" + INVALID_PARTICIPATION_NEGATIVEZERO, MESSAGE_INVALID_NEGATIVE_ZERO);
     }
 
     @Test

--- a/src/test/java/seedu/taskmaster/logic/parser/ParticipationCommandParserTest.java
+++ b/src/test/java/seedu/taskmaster/logic/parser/ParticipationCommandParserTest.java
@@ -6,7 +6,7 @@ import static seedu.taskmaster.logic.commands.CommandTestUtil.INVALID_PARTICIPAT
 import static seedu.taskmaster.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.PREAMBLE_ALL;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_INT;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_DOUBLE;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_STRING;
 import static seedu.taskmaster.logic.parser.CliSyntax.PREFIX_CLASS_PARTICIPATION;
 import static seedu.taskmaster.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -63,7 +63,7 @@ class ParticipationCommandParserTest {
         Index targetIndex = INDEX_FIRST_STUDENT;
         String inputScore = targetIndex.getOneBased() + " "
                 + PREFIX_CLASS_PARTICIPATION + VALID_SCORE_STRING;
-        ParticipationCommand expectedCommandPresent = new ParticipationCommand(targetIndex, VALID_SCORE_INT);
+        ParticipationCommand expectedCommandPresent = new ParticipationCommand(targetIndex, VALID_SCORE_DOUBLE);
         assertParseSuccess(parser, inputScore, expectedCommandPresent);
     }
 
@@ -71,7 +71,7 @@ class ParticipationCommandParserTest {
     public void parse_markAllStudents_success() {
         String inputScore = PREAMBLE_ALL + " "
                 + PREFIX_CLASS_PARTICIPATION + VALID_SCORE_STRING;
-        ParticipationCommand expectedCommandPresent = new ParticipationAllCommand(VALID_SCORE_INT);
+        ParticipationCommand expectedCommandPresent = new ParticipationAllCommand(VALID_SCORE_DOUBLE);
         assertParseSuccess(parser, inputScore, expectedCommandPresent);
     }
 }

--- a/src/test/java/seedu/taskmaster/model/ModelManagerTest.java
+++ b/src/test/java/seedu/taskmaster/model/ModelManagerTest.java
@@ -3,7 +3,7 @@ package seedu.taskmaster.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_INT;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_SCORE_DOUBLE;
 import static seedu.taskmaster.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 import static seedu.taskmaster.testutil.Assert.assertThrows;
 import static seedu.taskmaster.testutil.TypicalStudentRecords.ALICE_STUDENT_RECORD;
@@ -232,10 +232,10 @@ public class ModelManagerTest {
         modelManager.addSession(s);
         modelManager.changeSession(sName);
         modelManager.markStudentRecord(ALICE_STUDENT_RECORD, AttendanceType.PRESENT);
-        assertTrue(s.getStudentRecords().toString().equals("[e0123456|PRESENT|Class Participation Score: 0]"));
+        assertTrue(s.getStudentRecords().toString().equals("[e0123456|PRESENT|Class Participation Score: 0.00]"));
 
         modelManager.markStudentRecord(ALICE_STUDENT_RECORD, AttendanceType.ABSENT);
-        assertTrue(s.getStudentRecords().toString().equals("[e0123456|ABSENT|Class Participation Score: 0]"));
+        assertTrue(s.getStudentRecords().toString().equals("[e0123456|ABSENT|Class Participation Score: 0.00]"));
     }
 
     @Test
@@ -271,9 +271,9 @@ public class ModelManagerTest {
         modelManager.addSession(s);
         modelManager.changeSession(sName);
         modelManager.markStudentWithNusnetId(ALICE.getNusnetId(), AttendanceType.PRESENT);
-        assertTrue(s.getStudentRecords().toString().equals("[e0123456|PRESENT|Class Participation Score: 0]"));
+        assertEquals(s.getStudentRecords().toString(), "[e0123456|PRESENT|Class Participation Score: 0.00]");
         modelManager.markStudentWithNusnetId(ALICE.getNusnetId(), AttendanceType.ABSENT);
-        assertTrue(s.getStudentRecords().toString().equals("[e0123456|ABSENT|Class Participation Score: 0]"));
+        assertTrue(s.getStudentRecords().toString().equals("[e0123456|ABSENT|Class Participation Score: 0.00]"));
     }
 
     @Test
@@ -311,10 +311,10 @@ public class ModelManagerTest {
         studentRecords.add(BENSON_STUDENT_RECORD);
         modelManager.addSession(s);
         modelManager.changeSession(sName);
-        modelManager.scoreStudent(ALICE_STUDENT_RECORD, VALID_SCORE_INT);
-        assertTrue(s.getStudentRecords().toString().equals("[e0123456|NO_RECORD|Class Participation Score: 0]"));
-        modelManager.scoreStudent(ALICE_STUDENT_RECORD, (VALID_SCORE_INT + 2));
-        assertTrue(s.getStudentRecords().toString().equals("[e0123456|NO_RECORD|Class Participation Score: 2]"));
+        modelManager.scoreStudent(ALICE_STUDENT_RECORD, VALID_SCORE_DOUBLE);
+        assertTrue(s.getStudentRecords().toString().equals("[e0123456|NO_RECORD|Class Participation Score: 0.00]"));
+        modelManager.scoreStudent(ALICE_STUDENT_RECORD, (VALID_SCORE_DOUBLE + 2));
+        assertTrue(s.getStudentRecords().toString().equals("[e0123456|NO_RECORD|Class Participation Score: 2.00]"));
     }
 
     @Test
@@ -324,7 +324,7 @@ public class ModelManagerTest {
         ArrayList<StudentRecord> studentRecords = new ArrayList<>();
         studentRecords.add(ALICE_STUDENT_RECORD);
         studentRecords.add(BENSON_STUDENT_RECORD);
-        assertThrows(NoSessionException.class, () -> modelManager.scoreStudent(ALICE_STUDENT_RECORD, VALID_SCORE_INT));
+        assertThrows(NoSessionException.class, () -> modelManager.scoreStudent(ALICE_STUDENT_RECORD, VALID_SCORE_DOUBLE));
     }
 
     @Test
@@ -340,7 +340,7 @@ public class ModelManagerTest {
                 stds);
         modelManager.addSession(s);
         assertThrows(NoSessionSelectedException.class, () -> modelManager
-                .scoreStudent(ALICE_STUDENT_RECORD, VALID_SCORE_INT));
+                .scoreStudent(ALICE_STUDENT_RECORD, VALID_SCORE_DOUBLE));
     }
 
     @Test
@@ -353,10 +353,10 @@ public class ModelManagerTest {
                 stds);
         modelManager.addSession(s);
         modelManager.changeSession(sName);
-        modelManager.scoreStudentWithNusnetId(ALICE.getNusnetId(), VALID_SCORE_INT);
-        assertTrue(s.getStudentRecords().toString().equals("[e0123456|NO_RECORD|Class Participation Score: 0]"));
-        modelManager.scoreStudentWithNusnetId(ALICE.getNusnetId(), (VALID_SCORE_INT + 1));
-        assertTrue(s.getStudentRecords().toString().equals("[e0123456|NO_RECORD|Class Participation Score: 1]"));
+        modelManager.scoreStudentWithNusnetId(ALICE.getNusnetId(), VALID_SCORE_DOUBLE);
+        assertTrue(s.getStudentRecords().toString().equals("[e0123456|NO_RECORD|Class Participation Score: 0.00]"));
+        modelManager.scoreStudentWithNusnetId(ALICE.getNusnetId(), (VALID_SCORE_DOUBLE + 1));
+        assertTrue(s.getStudentRecords().toString().equals("[e0123456|NO_RECORD|Class Participation Score: 1.00]"));
     }
 
     @Test
@@ -364,7 +364,7 @@ public class ModelManagerTest {
         ArrayList<Student> stds = new ArrayList<Student>();
         stds.add(ALICE);
         assertThrows(NoSessionException.class, () -> modelManager
-                .scoreStudentWithNusnetId(ALICE.getNusnetId(), VALID_SCORE_INT));
+                .scoreStudentWithNusnetId(ALICE.getNusnetId(), VALID_SCORE_DOUBLE));
     }
 
     @Test
@@ -377,7 +377,7 @@ public class ModelManagerTest {
                 stds);
         modelManager.addSession(s);
         assertThrows(NoSessionSelectedException.class, () -> modelManager
-                .scoreStudentWithNusnetId(ALICE.getNusnetId(), VALID_SCORE_INT));
+                .scoreStudentWithNusnetId(ALICE.getNusnetId(), VALID_SCORE_DOUBLE));
     }
 
     @Test
@@ -394,15 +394,15 @@ public class ModelManagerTest {
                 stds);
         modelManager.addSession(s);
         modelManager.changeSession(sName);
-        modelManager.scoreAllStudents(studentRecords, VALID_SCORE_INT);
+        modelManager.scoreAllStudents(studentRecords, VALID_SCORE_DOUBLE);
 
         assertTrue(s.getStudentRecords().toString()
-                .equals("[e0123456|NO_RECORD|Class Participation Score: 0,"
-                        + " e0456789|NO_RECORD|Class Participation Score: 0]"));
-        modelManager.scoreAllStudents(studentRecords, (VALID_SCORE_INT + 2));
+                .equals("[e0123456|NO_RECORD|Class Participation Score: 0.00,"
+                        + " e0456789|NO_RECORD|Class Participation Score: 0.00]"));
+        modelManager.scoreAllStudents(studentRecords, (VALID_SCORE_DOUBLE + 2));
         assertTrue(s.getStudentRecords().toString()
-                .equals("[e0123456|NO_RECORD|Class Participation Score: 2,"
-                + " e0456789|NO_RECORD|Class Participation Score: 2]"));
+                .equals("[e0123456|NO_RECORD|Class Participation Score: 2.00,"
+                + " e0456789|NO_RECORD|Class Participation Score: 2.00]"));
     }
 
     @Test
@@ -413,7 +413,7 @@ public class ModelManagerTest {
         ArrayList<StudentRecord> studentRecords = new ArrayList<>();
         studentRecords.add(ALICE_STUDENT_RECORD);
         studentRecords.add(BENSON_STUDENT_RECORD);
-        assertThrows(NoSessionException.class, () -> modelManager.scoreAllStudents(studentRecords, VALID_SCORE_INT));
+        assertThrows(NoSessionException.class, () -> modelManager.scoreAllStudents(studentRecords, VALID_SCORE_DOUBLE));
     }
 
     @Test
@@ -430,7 +430,7 @@ public class ModelManagerTest {
                 stds);
         modelManager.addSession(s);
         assertThrows(NoSessionSelectedException.class, () -> modelManager
-                .scoreAllStudents(studentRecords, VALID_SCORE_INT));
+                .scoreAllStudents(studentRecords, VALID_SCORE_DOUBLE));
     }
 
     @Test
@@ -450,12 +450,12 @@ public class ModelManagerTest {
         modelManager.markAllStudentRecords(studentRecords, AttendanceType.PRESENT);
 
         assertTrue(s.getStudentRecords().toString()
-                .equals("[e0123456|PRESENT|Class Participation Score: 0,"
-                        + " e0456789|PRESENT|Class Participation Score: 0]"));
+                .equals("[e0123456|PRESENT|Class Participation Score: 0.00,"
+                        + " e0456789|PRESENT|Class Participation Score: 0.00]"));
         modelManager.markAllStudentRecords(studentRecords, AttendanceType.ABSENT);
         assertTrue(s.getStudentRecords().toString()
-                .equals("[e0123456|ABSENT|Class Participation Score: 0,"
-                        + " e0456789|ABSENT|Class Participation Score: 0]"));
+                .equals("[e0123456|ABSENT|Class Participation Score: 0.00,"
+                        + " e0456789|ABSENT|Class Participation Score: 0.00]"));
     }
 
     @Test

--- a/src/test/java/seedu/taskmaster/model/ModelManagerTest.java
+++ b/src/test/java/seedu/taskmaster/model/ModelManagerTest.java
@@ -324,7 +324,8 @@ public class ModelManagerTest {
         ArrayList<StudentRecord> studentRecords = new ArrayList<>();
         studentRecords.add(ALICE_STUDENT_RECORD);
         studentRecords.add(BENSON_STUDENT_RECORD);
-        assertThrows(NoSessionException.class, () -> modelManager.scoreStudent(ALICE_STUDENT_RECORD, VALID_SCORE_DOUBLE));
+        assertThrows(NoSessionException.class, () -> modelManager
+                .scoreStudent(ALICE_STUDENT_RECORD, VALID_SCORE_DOUBLE));
     }
 
     @Test

--- a/src/test/java/seedu/taskmaster/model/ModelManagerTest.java
+++ b/src/test/java/seedu/taskmaster/model/ModelManagerTest.java
@@ -306,11 +306,14 @@ public class ModelManagerTest {
         Session s = new Session(sName,
                 new SessionDateTime(LocalDateTime.now()),
                 stds);
+        ArrayList<StudentRecord> studentRecords = new ArrayList<>();
+        studentRecords.add(ALICE_STUDENT_RECORD);
+        studentRecords.add(BENSON_STUDENT_RECORD);
         modelManager.addSession(s);
         modelManager.changeSession(sName);
-        modelManager.scoreStudent(ALICE, VALID_SCORE_INT);
+        modelManager.scoreStudent(ALICE_STUDENT_RECORD, VALID_SCORE_INT);
         assertTrue(s.getStudentRecords().toString().equals("[e0123456|NO_RECORD|Class Participation Score: 0]"));
-        modelManager.scoreStudent(ALICE, (VALID_SCORE_INT + 2));
+        modelManager.scoreStudent(ALICE_STUDENT_RECORD, (VALID_SCORE_INT + 2));
         assertTrue(s.getStudentRecords().toString().equals("[e0123456|NO_RECORD|Class Participation Score: 2]"));
     }
 
@@ -318,7 +321,10 @@ public class ModelManagerTest {
     void scoreStudent_noSession_failure() {
         ArrayList<Student> stds = new ArrayList<Student>();
         stds.add(ALICE);
-        assertThrows(NoSessionException.class, () -> modelManager.scoreStudent(ALICE, VALID_SCORE_INT));
+        ArrayList<StudentRecord> studentRecords = new ArrayList<>();
+        studentRecords.add(ALICE_STUDENT_RECORD);
+        studentRecords.add(BENSON_STUDENT_RECORD);
+        assertThrows(NoSessionException.class, () -> modelManager.scoreStudent(ALICE_STUDENT_RECORD, VALID_SCORE_INT));
     }
 
     @Test
@@ -326,11 +332,15 @@ public class ModelManagerTest {
         SessionName sName = new SessionName("Test Session");
         ArrayList<Student> stds = new ArrayList<Student>();
         stds.add(ALICE);
+        ArrayList<StudentRecord> studentRecords = new ArrayList<>();
+        studentRecords.add(ALICE_STUDENT_RECORD);
+        studentRecords.add(BENSON_STUDENT_RECORD);
         Session s = new Session(sName,
                 new SessionDateTime(LocalDateTime.now()),
                 stds);
         modelManager.addSession(s);
-        assertThrows(NoSessionSelectedException.class, () -> modelManager.scoreStudent(ALICE, VALID_SCORE_INT));
+        assertThrows(NoSessionSelectedException.class, () -> modelManager
+                .scoreStudent(ALICE_STUDENT_RECORD, VALID_SCORE_INT));
     }
 
     @Test

--- a/src/test/java/seedu/taskmaster/model/ModelManagerTest.java
+++ b/src/test/java/seedu/taskmaster/model/ModelManagerTest.java
@@ -376,17 +376,20 @@ public class ModelManagerTest {
         ArrayList<Student> stds = new ArrayList<Student>();
         stds.add(ALICE);
         stds.add(BOB);
+        ArrayList<StudentRecord> studentRecords = new ArrayList<>();
+        studentRecords.add(ALICE_STUDENT_RECORD);
+        studentRecords.add(BENSON_STUDENT_RECORD);
         Session s = new Session(sName,
                 new SessionDateTime(LocalDateTime.now()),
                 stds);
         modelManager.addSession(s);
         modelManager.changeSession(sName);
-        modelManager.scoreAllStudents(stds, VALID_SCORE_INT);
+        modelManager.scoreAllStudents(studentRecords, VALID_SCORE_INT);
 
         assertTrue(s.getStudentRecords().toString()
                 .equals("[e0123456|NO_RECORD|Class Participation Score: 0,"
                         + " e0456789|NO_RECORD|Class Participation Score: 0]"));
-        modelManager.scoreAllStudents(stds, (VALID_SCORE_INT + 2));
+        modelManager.scoreAllStudents(studentRecords, (VALID_SCORE_INT + 2));
         assertTrue(s.getStudentRecords().toString()
                 .equals("[e0123456|NO_RECORD|Class Participation Score: 2,"
                 + " e0456789|NO_RECORD|Class Participation Score: 2]"));
@@ -397,7 +400,10 @@ public class ModelManagerTest {
         ArrayList<Student> stds = new ArrayList<Student>();
         stds.add(ALICE);
         stds.add(BOB);
-        assertThrows(NoSessionException.class, () -> modelManager.scoreAllStudents(stds, VALID_SCORE_INT));
+        ArrayList<StudentRecord> studentRecords = new ArrayList<>();
+        studentRecords.add(ALICE_STUDENT_RECORD);
+        studentRecords.add(BENSON_STUDENT_RECORD);
+        assertThrows(NoSessionException.class, () -> modelManager.scoreAllStudents(studentRecords, VALID_SCORE_INT));
     }
 
     @Test
@@ -406,11 +412,15 @@ public class ModelManagerTest {
         ArrayList<Student> stds = new ArrayList<Student>();
         stds.add(ALICE);
         stds.add(BOB);
+        ArrayList<StudentRecord> studentRecords = new ArrayList<>();
+        studentRecords.add(ALICE_STUDENT_RECORD);
+        studentRecords.add(BENSON_STUDENT_RECORD);
         Session s = new Session(sName,
                 new SessionDateTime(LocalDateTime.now()),
                 stds);
         modelManager.addSession(s);
-        assertThrows(NoSessionSelectedException.class, () -> modelManager.scoreAllStudents(stds, VALID_SCORE_INT));
+        assertThrows(NoSessionSelectedException.class, () -> modelManager
+                .scoreAllStudents(studentRecords, VALID_SCORE_INT));
     }
 
     @Test


### PR DESCRIPTION
Fixes for the class participation score

## Summary
* Fixed bug found by @josuaaah when scoring after student removed from the list of student, the index corresponds to the indes in the *Student List* instead of the *Session*.
* Fixed one extra bug related to the above; score all now scores every student in the session instead of the session list.
* Documentation of score in the code (`ParticipationCommand`, `ParticipationAllCommand`) is updated. Closes #128, #131 (thanks @chloelee767 for the bug report!)
* Updated the default score documentation to have 0 and 10 inclusive in the code. Close #132.
* Implemented limit on score (0-10 inclusive) and changed to double (2dp) for more granularity. Changed the error message to be more descriptive. Closes #122 (thanks @jeffreytjs for the bug report!)
* Fix error message when scoring a user outside of the given index for the list. Closes #138

## Type of change
<Select all that apply, in the form [x]>
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Testing

Tests are just modified to reflect the above changes (e.g. change of types)
* OS: Ubuntu 20.04 LTS


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
