### PR TITLE
Fix studentrecord display bug

### DIFF
--- a/src/main/java/seedu/taskmaster/model/ModelManager.java
+++ b/src/main/java/seedu/taskmaster/model/ModelManager.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
-import javafx.collections.ObservableListBase;
 import javafx.collections.transformation.FilteredList;
 import seedu.taskmaster.commons.core.GuiSettings;
 import seedu.taskmaster.commons.core.LogsCenter;
@@ -36,6 +35,7 @@ public class ModelManager implements Model {
     private final FilteredList<Student> filteredStudents;
     private final FilteredList<Session> filteredSessions;
     private FilteredList<StudentRecord> filteredStudentRecords;
+    private Predicate<StudentRecord> studentRecordPredicate;
 
     /**
      * Initializes a ModelManager with the given Taskmaster, SessionList, and userPrefs.
@@ -53,6 +53,7 @@ public class ModelManager implements Model {
         filteredStudents = new FilteredList<>(this.taskmaster.getStudentList());
         filteredSessions = new FilteredList<>(this.taskmaster.getSessionList());
         filteredStudentRecords = null;
+        studentRecordPredicate = PREDICATE_SHOW_ALL_STUDENT_RECORDS;
     }
 
     public ModelManager(ReadOnlyTaskmaster taskmaster, ReadOnlyUserPrefs userPrefs) {
@@ -123,8 +124,10 @@ public class ModelManager implements Model {
 
     @Override
     public void addSession(Session session) {
-        taskmaster.addSession(session);
         updateFilteredSessionList(PREDICATE_SHOW_ALL_SESSIONS);
+        filteredStudentRecords = null;
+        taskmaster.addSession(session);
+        taskmaster.changeSession(session.getSessionName());
     }
 
     /**
@@ -134,6 +137,9 @@ public class ModelManager implements Model {
     public void changeSession(SessionName sessionName) {
         if (sessionName == null) {
             filteredStudentRecords = null;
+            studentRecordPredicate = PREDICATE_SHOW_ALL_STUDENT_RECORDS;
+            taskmaster.changeSession(null);
+            return;
         } else {
             /*
              * Note that the implementation of this method requires that the filteredStudentRecords field is updated
@@ -141,11 +147,16 @@ public class ModelManager implements Model {
              * it must be loaded first.
              */
             assert taskmaster.hasSession(sessionName);
+
+            studentRecordPredicate = PREDICATE_SHOW_ALL_STUDENT_RECORDS;
+            // Update filteredStudentRecords before Session is changed.
             filteredStudentRecords = new FilteredList<>(taskmaster.getSession(sessionName).getStudentRecords());
-            filteredStudentRecords.setPredicate(PREDICATE_SHOW_ALL_STUDENT_RECORDS);
+
+            taskmaster.changeSession(sessionName);
         }
 
-        taskmaster.changeSession(sessionName);
+
+
     }
 
     @Override
@@ -268,20 +279,12 @@ public class ModelManager implements Model {
         }
 
         if (filteredStudentRecords == null) {
-            return new ObservableListBase<StudentRecord>() {
-                @Override
-                public StudentRecord get(int i) {
-                    return null;
-                }
-
-                @Override
-                public int size() {
-                    return 0;
-                }
-            };
-        } else {
-            return filteredStudentRecords;
+            filteredStudentRecords = new FilteredList<>(taskmaster.getCurrentSession().get().getStudentRecords());
+            studentRecordPredicate = PREDICATE_SHOW_ALL_STUDENT_RECORDS;
         }
+
+        filteredStudentRecords.setPredicate(studentRecordPredicate);
+        return filteredStudentRecords;
     }
 
     @Override
@@ -298,6 +301,7 @@ public class ModelManager implements Model {
     @Override
     public void updateFilteredStudentRecordList(Predicate<StudentRecord> predicate) {
         requireNonNull(predicate);
+        studentRecordPredicate = predicate;
         filteredStudentRecords.setPredicate(predicate);
     }
 
@@ -305,7 +309,9 @@ public class ModelManager implements Model {
     @Override
     public void showLowestScoringStudents() {
         double lowestScore = taskmaster.getLowestScore();
-        filteredStudentRecords.setPredicate(new ScoreEqualsPredicate(lowestScore));
+        studentRecordPredicate = new ScoreEqualsPredicate(lowestScore);
+
+        updateFilteredStudentRecordList(studentRecordPredicate);
     }
 
     @Override


### PR DESCRIPTION
# Fix studentrecord display bug

## Summary
The problems generally because calling `currentSession.setValue` in the `Taskmaster#addSession` and `Taskmaster#changeSession` methods prompts the UI to call `Model#getFilteredStudentRecordList` before the relevant field in Model is updated.

Closes #200

## Type of change
<Select all that apply, in the form [x]>
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
