### PR TITLE
Fix bug #215

### DIFF
--- a/src/main/java/seedu/taskmaster/model/student/Student.java
+++ b/src/main/java/seedu/taskmaster/model/student/Student.java
@@ -73,9 +73,7 @@ public class Student {
             return false;
         }
 
-        return otherStudent.getNusnetId().equals(getNusnetId())
-                || (otherStudent.getName().equals(getName())
-                && (otherStudent.getTelegram().equals(getTelegram()) || otherStudent.getEmail().equals(getEmail())));
+        return otherStudent.getNusnetId().equals(getNusnetId());
     }
 
     /**

--- a/src/test/java/seedu/taskmaster/model/TaskmasterTest.java
+++ b/src/test/java/seedu/taskmaster/model/TaskmasterTest.java
@@ -3,8 +3,9 @@ package seedu.taskmaster.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_NUSNETID_BOB;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_TELEGRAM_BOB;
 import static seedu.taskmaster.testutil.Assert.assertThrows;
 import static seedu.taskmaster.testutil.TypicalStudents.ALICE;
 import static seedu.taskmaster.testutil.TypicalStudents.getTypicalSession;
@@ -57,8 +58,8 @@ public class TaskmasterTest {
     @Test
     public void resetData_withDuplicateStudents_throwsDuplicateStudentException() {
         // Two students with the same identity fields
-        Student editedAlice = new StudentBuilder(ALICE).withNusnetId(VALID_NUSNETID_BOB).withTags(VALID_TAG_HUSBAND)
-                .build();
+        Student editedAlice = new StudentBuilder(ALICE).withEmail(VALID_EMAIL_BOB).withTelegram(VALID_TELEGRAM_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
         List<Student> newStudents = Arrays.asList(ALICE, editedAlice);
         TaskmasterStub newData = new TaskmasterStub(newStudents);
 
@@ -166,8 +167,8 @@ public class TaskmasterTest {
     @Test
     public void hasStudent_studentWithSameIdentityFieldsInStudentList_returnsTrue() {
         taskmaster.addStudent(ALICE);
-        Student editedAlice = new StudentBuilder(ALICE).withNusnetId(VALID_NUSNETID_BOB).withTags(VALID_TAG_HUSBAND)
-                .build();
+        Student editedAlice = new StudentBuilder(ALICE).withEmail(VALID_EMAIL_BOB).withTelegram(VALID_TELEGRAM_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
         assertTrue(taskmaster.hasStudent(editedAlice));
     }
 

--- a/src/test/java/seedu/taskmaster/model/student/StudentTest.java
+++ b/src/test/java/seedu/taskmaster/model/student/StudentTest.java
@@ -40,19 +40,19 @@ public class StudentTest {
         editedAlice = new StudentBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertTrue(ALICE.isSameStudent(editedAlice));
 
-        // same name, same telegram, different attributes -> returns true
+        // same name, same telegram, different nusnetId -> returns false
         editedAlice = new StudentBuilder(ALICE).withEmail(VALID_EMAIL_BOB).withNusnetId(VALID_NUSNETID_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
-        assertTrue(ALICE.isSameStudent(editedAlice));
+        assertFalse(ALICE.isSameStudent(editedAlice));
 
-        // same name, same email, different attributes -> returns true
+        // same name, same email, different nusnetId -> returns false
         editedAlice = new StudentBuilder(ALICE).withTelegram(VALID_TELEGRAM_BOB).withNusnetId(VALID_NUSNETID_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
-        assertTrue(ALICE.isSameStudent(editedAlice));
+        assertFalse(ALICE.isSameStudent(editedAlice));
 
-        // same name, same telegram, same email, different attributes -> returns true
+        // same name, same telegram, same email, different nusnetId -> returns false
         editedAlice = new StudentBuilder(ALICE).withNusnetId(VALID_NUSNETID_BOB).withTags(VALID_TAG_HUSBAND).build();
-        assertTrue(ALICE.isSameStudent(editedAlice));
+        assertFalse(ALICE.isSameStudent(editedAlice));
     }
 
     @Test

--- a/src/test/java/seedu/taskmaster/model/student/UniqueStudentListTest.java
+++ b/src/test/java/seedu/taskmaster/model/student/UniqueStudentListTest.java
@@ -3,8 +3,10 @@ package seedu.taskmaster.model.student;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_NUSNETID_BOB;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.taskmaster.logic.commands.CommandTestUtil.VALID_TELEGRAM_BOB;
 import static seedu.taskmaster.testutil.Assert.assertThrows;
 import static seedu.taskmaster.testutil.TypicalStudents.ALICE;
 import static seedu.taskmaster.testutil.TypicalStudents.BOB;
@@ -42,8 +44,8 @@ public class UniqueStudentListTest {
     @Test
     public void contains_studentWithSameIdentityFieldsInList_returnsTrue() {
         uniqueStudentList.add(ALICE);
-        Student editedAlice = new StudentBuilder(ALICE).withNusnetId(VALID_NUSNETID_BOB).withTags(VALID_TAG_HUSBAND)
-                .build();
+        Student editedAlice = new StudentBuilder(ALICE).withEmail(VALID_EMAIL_BOB).withTelegram(VALID_TELEGRAM_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
         assertTrue(uniqueStudentList.contains(editedAlice));
     }
 


### PR DESCRIPTION
# Fix bug #215

## Summary
A student can be edited to have the same NUSNET ID of another existing
student in the list.

A student is identified only by their NUSNET ID, all other fields are
not identity fields.

Let's fix the isSameStudent method to reflect this design.
Closes #215

## Type of change
<Select all that apply, in the form [x]>
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
