### PR TITLE
Change score all behaviour

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -21,8 +21,7 @@ TAskmaster is a **desktop app for managing students, optimised for use via a Com
     - [Changing the current session: `goto`](#changing-the-current-session-goto "Go to Changing the current session")
     - [Marking a student's attendance: `mark`](#marking-a-students-attendance-mark "Go to Marking a student's attendance")
     - [Marking all students' attendance: `mark all`](#marking-all-students-attendance-mark-all "Go to Marking all students' attendance")
-    - [Scoring a student's participation: `score`](#scoring-a-students-participation-score "Go to Scoring a student's participation mark")
-    - [Scoring all students' participation: `score all`](#scoring-all-students-participation-score-all "Go to Scoring all students' participation marks")
+    - [Scoring students' participation: `score`](#scoring-students-participation-score "Go to Scoring students' participation mark")
     - [View lowest scoring students: `lowest-score`](#View-lowest-scoring-students-lowest-score "Go to View lowest scoring students")
     - [Clear all students: `clear`](#clearing-all-entries-clear "Go to Clearing all entries")
     - [Exit the program: `exit`](#exiting-the-program-exit "Go to Exiting the program")
@@ -209,8 +208,8 @@ mark all a/present
 mark 2 a/absent
 ```
 
-### Scoring student participation: `score`
-Scores the participation of the specified student in the session.
+### Scoring students' participation: `score`
+Scores the participation of student(s) in the session.
 ```
 score INDEX cp/SCORE
 ```
@@ -218,27 +217,18 @@ score INDEX cp/SCORE
 - The `INDEX` **must be a positive integer** that exists in said list.
 - The `SCORE` **must be a non-negative number** between 0 and 10, inclusive. 
 Taskmaster supports detailed score up to 2 decimal places.
-For scores with more than 2 decimal places, the score will be rounded to the nearest 2 decimal places.
+For scores with more than 2 decimal places, the score will be rounded to the nearest 2 decimal places.  
+Taskmaster supports scoring students' participation score even though the student is absent, to allow for
+module-specific instructions (e.g. a module coordinator instructs the TA to give
+a participation mark of 6 if a valid MC is given)
+
+To mark all students **who are present**, you can replace the `INDEX` by the keyword `all`.
 
 Example Usage:
 ```
 score 1 cp/5
 score 3 cp/6.9
 score 4 cp/4.21
-```
-
-### Scoring all students' participation: `score all`
-Scores the participation of all students in the session.
-```
-score all cp/SCORE
-```
-- Scores the participation of all students shown in the displayed student record list.
-- The `SCORE` **must be a non-negative number** between 0 and 10, inclusive. 
-Taskmaster supports detailed score up to 2 decimal places.
-For scores with more than 2 decimal places, the score will be rounded to the nearest 2 decimal places.
-
-Example Usage:
-```
 score all cp/10
 score all cp/2.94
 ```

--- a/src/main/java/seedu/taskmaster/model/ModelManager.java
+++ b/src/main/java/seedu/taskmaster/model/ModelManager.java
@@ -226,6 +226,7 @@ public class ModelManager implements Model {
     public void scoreAllStudents(List<StudentRecord> students, double score) {
         List<NusnetId> nusnetIds = students
                 .stream()
+                .filter(s -> s.getAttendanceType() == AttendanceType.PRESENT)
                 .map(StudentRecord::getNusnetId)
                 .collect(Collectors.toList());
 

--- a/src/test/java/seedu/taskmaster/model/ModelManagerTest.java
+++ b/src/test/java/seedu/taskmaster/model/ModelManagerTest.java
@@ -360,18 +360,15 @@ public class ModelManagerTest {
     void scoreAllStudents() {
         Session s = initSessionWithAliceAndBenson();
         SessionName sName = new SessionName("Test Session");
-        ArrayList<StudentRecord> studentRecords = new ArrayList<>();
-        studentRecords.add(ALICE_STUDENT_RECORD);
-        studentRecords.add(BENSON_STUDENT_RECORD);
         modelManager.addSession(s);
         modelManager.changeSession(sName);
-        modelManager.scoreAllStudents(studentRecords, VALID_SCORE_DOUBLE);
-
-        assertEquals("[e0123456|NO_RECORD|Class Participation Score: 0.00,"
-                + " e0456789|NO_RECORD|Class Participation Score: 0.00]", s.getStudentRecords().toString());
-        modelManager.scoreAllStudents(studentRecords, (VALID_SCORE_DOUBLE + 2));
-        assertEquals("[e0123456|NO_RECORD|Class Participation Score: 2.00,"
-                + " e0456789|NO_RECORD|Class Participation Score: 2.00]", s.getStudentRecords().toString());
+        List<StudentRecord> studentRecords = modelManager.getFilteredStudentRecordList();
+        modelManager.markAllStudentRecords(studentRecords, AttendanceType.PRESENT);
+        assertEquals("[e0123456|PRESENT|Class Participation Score: 0.00,"
+                + " e0456789|PRESENT|Class Participation Score: 0.00]", s.getStudentRecords().toString());
+        modelManager.scoreAllStudents(studentRecords, 2);
+        assertEquals("[e0123456|PRESENT|Class Participation Score: 2.00,"
+                + " e0456789|PRESENT|Class Participation Score: 2.00]", s.getStudentRecords().toString());
     }
 
     @Test
@@ -384,11 +381,9 @@ public class ModelManagerTest {
 
     @Test
     void scoreAllStudents_sessionNotSelected_failure() {
-        ArrayList<StudentRecord> studentRecords = new ArrayList<>();
-        studentRecords.add(ALICE_STUDENT_RECORD);
-        studentRecords.add(BENSON_STUDENT_RECORD);
         Session s = initSessionWithAliceAndBenson();
         modelManager.addSession(s);
+        List<StudentRecord> studentRecords = modelManager.getFilteredStudentRecordList();
         modelManager.changeSession(null);
         assertThrows(NoSessionSelectedException.class, () -> modelManager
                 .scoreAllStudents(studentRecords, VALID_SCORE_DOUBLE));
@@ -398,11 +393,9 @@ public class ModelManagerTest {
     void markAllStudents() {
         Session s = initSessionWithAliceAndBenson();
         SessionName sName = new SessionName("Test Session");
-        ArrayList<StudentRecord> studentRecords = new ArrayList<>();
-        studentRecords.add(ALICE_STUDENT_RECORD);
-        studentRecords.add(BENSON_STUDENT_RECORD);
         modelManager.addSession(s);
         modelManager.changeSession(sName);
+        List<StudentRecord> studentRecords = modelManager.getFilteredStudentRecordList();
         modelManager.markAllStudentRecords(studentRecords, AttendanceType.PRESENT);
 
         assertEquals("[e0123456|PRESENT|Class Participation Score: 0.00,"


### PR DESCRIPTION
# Change `score all` behaviour

## Summary
`score all` should just mark the students who are present. This is an adaptation for a feature flaw pointed out by a fellow student.  
It makes more sense that `score all` only marks students' who are present, rather than all students. The behaviour for `score` which can score absent student should be maintained in case there are module-specific instructions, e.g. score 6 for those who submits valid MC. Closes #218

## Type of change
<Select all that apply, in the form [x]>
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Testing
Changed the testcase to include case where student is marked as present  
* OS: Ubuntu


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
