### PR TITLE
Change lowest-score to only show present students

### DIFF
--- a/src/main/java/seedu/taskmaster/model/record/ScoreEqualsPredicate.java
+++ b/src/main/java/seedu/taskmaster/model/record/ScoreEqualsPredicate.java
@@ -15,7 +15,8 @@ public class ScoreEqualsPredicate implements Predicate<StudentRecord> {
 
     @Override
     public boolean test(StudentRecord studentRecord) {
-        return studentRecord.getClassParticipation().getRawScore() == desiredScore;
+        return studentRecord.getAttendanceType().equals(AttendanceType.PRESENT)
+                && studentRecord.getClassParticipation().getRawScore() == desiredScore;
     }
 
     @Override

--- a/src/main/java/seedu/taskmaster/model/record/StudentRecordListManager.java
+++ b/src/main/java/seedu/taskmaster/model/record/StudentRecordListManager.java
@@ -142,10 +142,12 @@ public class StudentRecordListManager implements StudentRecordList {
         double lowestScore = Integer.MAX_VALUE;
         for (int i = 0; i < internalList.size(); i++) {
             StudentRecord studentRecord = internalList.get(i);
-            double score = studentRecord.getClassParticipation().getRawScore();
+            if (studentRecord.getAttendanceType().equals(AttendanceType.PRESENT)) {
+                double score = studentRecord.getClassParticipation().getRawScore();
 
-            if (score < lowestScore) {
-                lowestScore = score;
+                if (score < lowestScore) {
+                    lowestScore = score;
+                }
             }
         }
 

--- a/src/test/java/seedu/taskmaster/logic/commands/LowestScoreCommandTest.java
+++ b/src/test/java/seedu/taskmaster/logic/commands/LowestScoreCommandTest.java
@@ -6,7 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.taskmaster.commons.core.Messages.MESSAGE_RECORDS_LISTED_OVERVIEW;
 import static seedu.taskmaster.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.taskmaster.testutil.TypicalStudents.getScoredTaskmaster;
-import static seedu.taskmaster.testutil.TypicalStudents.getTypicalStudentRecords;
+import static seedu.taskmaster.testutil.TypicalStudents.getTypicalPresentStudentRecords;
+import static seedu.taskmaster.testutil.TypicalStudents.markAllAsPresentInTypicalSession;
 
 import org.junit.jupiter.api.Test;
 
@@ -45,12 +46,15 @@ public class LowestScoreCommandTest {
     public void execute_unscoredSession_allStudentsFound() {
         model.changeSession(new SessionName("Typical session"));
         expectedModel.changeSession(new SessionName("Typical session"));
+        markAllAsPresentInTypicalSession(model.getCurrentSession().get());
+        markAllAsPresentInTypicalSession(expectedModel.getCurrentSession().get());
+
         String expectedMessage = String.format(MESSAGE_RECORDS_LISTED_OVERVIEW, 7);
         LowestScoreCommand command = new LowestScoreCommand();
         ScoreEqualsPredicate predicate = new ScoreEqualsPredicate(0);
         expectedModel.updateFilteredStudentRecordList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(getTypicalStudentRecords(), model.getFilteredStudentRecordList());
+        assertEquals(getTypicalPresentStudentRecords(), model.getFilteredStudentRecordList());
     }
 
     @Test

--- a/src/test/java/seedu/taskmaster/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/taskmaster/testutil/TypicalStudents.java
@@ -18,12 +18,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import seedu.taskmaster.model.Taskmaster;
+import seedu.taskmaster.model.record.AttendanceType;
 import seedu.taskmaster.model.record.StudentRecord;
 import seedu.taskmaster.model.session.Session;
 import seedu.taskmaster.model.session.SessionDateTime;
 import seedu.taskmaster.model.session.SessionList;
 import seedu.taskmaster.model.session.SessionListManager;
 import seedu.taskmaster.model.session.SessionName;
+import seedu.taskmaster.model.student.NusnetId;
 import seedu.taskmaster.model.student.Student;
 
 /**
@@ -131,6 +133,7 @@ public class TypicalStudents {
                 new SessionName("Typical session 2"),
                 new SessionDateTime(LocalDateTime.of(2020, 1, 1, 12, 0)),
                 getTypicalStudents());
+        modifiedSession.markAllStudentAttendances(getTypicalNusnetIds(), AttendanceType.PRESENT);
         modifiedSession.scoreAllParticipation(
                 getTypicalStudents().stream().map(Student::getNusnetId).collect(Collectors.toList()), 5);
         modifiedSession.scoreStudentParticipation(ALICE.getNusnetId(), 4);
@@ -194,10 +197,36 @@ public class TypicalStudents {
     }
 
     /**
+     * Returns a list containing the NUSNET IDs of the typical students.
+     */
+    public static List<NusnetId> getTypicalNusnetIds() {
+        return getTypicalStudents().stream()
+                .map(Student::getNusnetId)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Marks all students in a typical session as present.
+     */
+    public static void markAllAsPresentInTypicalSession(Session typicalSession) {
+        typicalSession.markAllStudentAttendances(getTypicalNusnetIds(), AttendanceType.PRESENT);
+    }
+
+    /**
      * Returns a list containing the StudentRecords of all the typical students,
      * without modified ClassParticipation and Attendance fields.
      */
     public static List<StudentRecord> getTypicalStudentRecords() {
         return getTypicalSession().getStudentRecords();
+    }
+
+    /**
+     * Returns a list containing the StudentRecords of all the typical students marked as present,
+     * without modified ClassParticipation and Attendance fields.
+     */
+    public static List<StudentRecord> getTypicalPresentStudentRecords() {
+        Session typicalSession = getTypicalSession();
+        markAllAsPresentInTypicalSession(typicalSession);
+        return typicalSession.getStudentRecords();
     }
 }


### PR DESCRIPTION
# Change lowest-score to only show present students

## Summary
Since a user would use lowest-score to get students to call on to ask questions, it should only show
students that are present at the session.

## Type of change
<Select all that apply, in the form [x]>
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
