### PR TITLE
Revert SceneBuilder's automatic magical star imports

### DIFF
--- a/src/main/resources/view/ListDisplayPanel.fxml
+++ b/src/main/resources/view/ListDisplayPanel.fxml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.AnchorPane?>
 
 <AnchorPane xmlns="http://javafx.com/javafx/11.0.0" xmlns:fx="http://javafx.com/fxml/1">
    <children>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.layout.StackPane?>
 
 <StackPane fx:id="placeHolder" maxHeight="-Infinity" minHeight="-Infinity" prefHeight="100.0" styleClass="black-pane" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
   <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true" />


### PR DESCRIPTION
# Revert SceneBuilder's automatic magical star imports

## Summary
<Summary of the change>
SceneBuilder likes to import everything together all at once. Let's change that!